### PR TITLE
Add bulletin handler and blank mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Controller for handling articles on ONS website
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 5s        | The graceful shutdown timeout in seconds (`time.Duration` format)
 | HEALTHCHECK_INTERVAL         | 30s       | Time between self-healthchecks (`time.Duration` format)
 | HEALTHCHECK_CRITICAL_TIMEOUT | 90s       | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
-| HELLO_WORLD_EMPHASISE        | true      | Example boolean flag to control whether the 'Hello World' greeting should be emphasised with "!"
 
 ### Contributing
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,14 +6,12 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-// TODO: remove hello world example config option
 // Config represents service configuration for dp-frontend-articles-controller
 type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
-	HelloWorldEmphasise        bool          `envconfig:"HELLO_WORLD_EMPHASISE"`
 }
 
 var cfg *Config
@@ -30,7 +28,6 @@ func Get() (*Config, error) {
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
-		HelloWorldEmphasise:        true,
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,8 +24,6 @@ func TestConfig(t *testing.T) {
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
-				// TODO: Remove assertion once configuration variable has been removed from config.go
-				So(cfg.HelloWorldEmphasise, ShouldEqual, true)
 			})
 
 			Convey("Then a second call to config should return the same config", func() {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -26,20 +26,19 @@ func setStatusCode(req *http.Request, w http.ResponseWriter, err error) {
 	w.WriteHeader(status)
 }
 
-// TODO: remove hello world example handler
-// HelloWorld Handler
-func HelloWorld(cfg config.Config) http.HandlerFunc {
+// Bulletin handles bulletin requests
+func Bulletin(cfg config.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		helloWorld(w, req, cfg)
+		bulletin(w, req, cfg)
 	}
 }
 
-func helloWorld(w http.ResponseWriter, req *http.Request, cfg config.Config) {
+func bulletin(w http.ResponseWriter, req *http.Request, cfg config.Config) {
 	ctx := req.Context()
-	greetingsModel := mapper.HelloModel{Greeting: "Hello", Who: "World"}
-	m := mapper.HelloWorld(ctx, greetingsModel, cfg)
+	bulletin := mapper.Bulletin{Name: req.URL.EscapedPath()}
+	model := mapper.Blank(ctx, bulletin, cfg)
 
-	b, err := json.Marshal(m)
+	b, err := json.Marshal(model)
 	if err != nil {
 		setStatusCode(req, w, err)
 		return

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -2,27 +2,22 @@ package mapper
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ONSdigital/dp-frontend-articles-controller/config"
 )
 
-// TODO: remove hello world example mapper and models
-
-type HelloModel struct {
-	Greeting string `json:"greeting"`
-	Who      string `json:"who"`
+type Bulletin struct {
+	// TODO define
+	Name string `json:"name"`
 }
 
-type HelloWorldModel struct {
-	HelloWho string `json:"hello-who"`
+type BulletinModel struct {
+	// TODO define
+	Name string `json:"model-name"`
 }
 
-func HelloWorld(ctx context.Context, hm HelloModel, cfg config.Config) HelloWorldModel {
-	var hwm HelloWorldModel
-	hwm.HelloWho = fmt.Sprintf("%s %s", hm.Greeting, hm.Who)
-	if cfg.HelloWorldEmphasise {
-		hwm.HelloWho += "!"
-	}
-	return hwm
+func Blank(ctx context.Context, bulletin Bulletin, cfg config.Config) BulletinModel {
+	var model BulletinModel
+	model.Name = bulletin.Name
+	return model
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -9,25 +9,22 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-// TODO: remove example test case
 func TestUnitMapper(t *testing.T) {
 	ctx := context.Background()
 
-	Convey("test mapper adds emphasis to hello world string when set in config", t, func() {
+	Convey("Blank maps correctly", t, func() {
 		cfg := config.Config{
 			BindAddr:                   "1234",
 			GracefulShutdownTimeout:    0,
 			HealthCheckInterval:        0,
 			HealthCheckCriticalTimeout: 0,
-			HelloWorldEmphasise:        true,
 		}
 
-		hm := HelloModel{
-			Greeting: "Hello",
-			Who:      "World",
+		bulletin := Bulletin{
+			Name: "test",
 		}
 
-		hw := HelloWorld(ctx, hm, cfg)
-		So(hw.HelloWho, ShouldEqual, "Hello World!")
+		model := Blank(ctx, bulletin, cfg)
+		So(model.Name, ShouldEqual, bulletin.Name)
 	})
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -20,7 +20,5 @@ type Clients struct {
 func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients) {
 	log.Info(ctx, "adding routes")
 	r.StrictSlash(true).Path("/health").HandlerFunc(c.HealthCheckHandler)
-
-	// TODO: remove hello world example handler route
-	r.StrictSlash(true).Path("/helloworld").Methods("GET").HandlerFunc(handlers.HelloWorld(*cfg))
+	r.StrictSlash(true).Path("/{uri:.*}").Methods("GET").HandlerFunc(handlers.Bulletin(*cfg))
 }


### PR DESCRIPTION
### What
This is some foundation work for bulletins: adding a handler and a blank mapper

### How to review

Check the code.
The new endpoint can be tested by running `make debug` and going to `localhost:26500/any/path` - it should return 200 and a json containing the path in `model-name`

### Who can review

Anyone but me
