### PR TITLE
Retrieve bulletin from articles API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-articles-controller
 go 1.17
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.4.1
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.7.0
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-net v1.2.0
 	github.com/ONSdigital/dp-renderer v1.9.0
@@ -17,6 +17,7 @@ require (
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/ONSdigital/dp-api-clients-go v1.41.1 // indirect
+	github.com/ONSdigital/log.go v1.1.0 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2 // indirect
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-api-clients-go v1.41.1 h1:xkeT6dCTFSAoBpZxgiJUiuqgcfjCX+c52CIiZo1Y2iU=
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.4.1 h1:oembOaTJ+lXxhm2HI1Gump18fD4o4sg0SC4GZ0LYLF8=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.4.1/go.mod h1:oB+Pw1BJlLHUh+a6BJY52VFTRGBEM5RSPlg2Xkq7D9k=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.7.0 h1:1MXb7ihnzY4dqOnNptfll4R890oOocaMJeRd1oI13jw=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.7.0/go.mod h1:oB+Pw1BJlLHUh+a6BJY52VFTRGBEM5RSPlg2Xkq7D9k=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-healthcheck v1.1.0 h1:fKOf8MMe8l4EW28ljX0wNZ5oZTgx/slAs7lyEx4eq2c=
 github.com/ONSdigital/dp-healthcheck v1.1.0/go.mod h1:vZwyjMJiCHjp/sJ2R1ZEqzZT0rJ0+uHVGwxqdP4J5vg=

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -4,7 +4,8 @@ import (
 	context "context"
 	"io"
 
-	zebedee "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
+	"github.com/ONSdigital/dp-api-clients-go/v2/articles"
+	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-renderer/model"
 )
 
@@ -25,6 +26,10 @@ type RenderClient interface {
 
 // ZebedeeClient is an interface for zebedee client
 type ZebedeeClient interface {
-	GetBulletin(ctx context.Context, userAccessToken, lang, uri string) (zebedee.Bulletin, error)
 	GetBreadcrumb(ctx context.Context, userAccessToken, collectionID, lang, uri string) ([]zebedee.Breadcrumb, error)
+}
+
+// ArticlesApiClient is an interface for the Articles API client
+type ArticlesApiClient interface {
+	GetLegacyBulletin(ctx context.Context, userAccessToken, collectionID, lang, uri string) (*articles.Bulletin, error)
 }

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -9,6 +9,7 @@ import (
 	io "io"
 	reflect "reflect"
 
+	articles "github.com/ONSdigital/dp-api-clients-go/v2/articles"
 	zebedee "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	model "github.com/ONSdigital/dp-renderer/model"
 	gomock "github.com/golang/mock/gomock"
@@ -152,17 +153,40 @@ func (mr *MockZebedeeClientMockRecorder) GetBreadcrumb(ctx, userAccessToken, col
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBreadcrumb", reflect.TypeOf((*MockZebedeeClient)(nil).GetBreadcrumb), ctx, userAccessToken, collectionID, lang, uri)
 }
 
-// GetBulletin mocks base method.
-func (m *MockZebedeeClient) GetBulletin(ctx context.Context, userAccessToken, lang, uri string) (zebedee.Bulletin, error) {
+// MockArticlesApiClient is a mock of ArticlesApiClient interface.
+type MockArticlesApiClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockArticlesApiClientMockRecorder
+}
+
+// MockArticlesApiClientMockRecorder is the mock recorder for MockArticlesApiClient.
+type MockArticlesApiClientMockRecorder struct {
+	mock *MockArticlesApiClient
+}
+
+// NewMockArticlesApiClient creates a new mock instance.
+func NewMockArticlesApiClient(ctrl *gomock.Controller) *MockArticlesApiClient {
+	mock := &MockArticlesApiClient{ctrl: ctrl}
+	mock.recorder = &MockArticlesApiClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockArticlesApiClient) EXPECT() *MockArticlesApiClientMockRecorder {
+	return m.recorder
+}
+
+// GetLegacyBulletin mocks base method.
+func (m *MockArticlesApiClient) GetLegacyBulletin(ctx context.Context, userAccessToken, collectionID, lang, uri string) (*articles.Bulletin, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBulletin", ctx, userAccessToken, lang, uri)
-	ret0, _ := ret[0].(zebedee.Bulletin)
+	ret := m.ctrl.Call(m, "GetLegacyBulletin", ctx, userAccessToken, collectionID, lang, uri)
+	ret0, _ := ret[0].(*articles.Bulletin)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetBulletin indicates an expected call of GetBulletin.
-func (mr *MockZebedeeClientMockRecorder) GetBulletin(ctx, userAccessToken, lang, uri interface{}) *gomock.Call {
+// GetLegacyBulletin indicates an expected call of GetLegacyBulletin.
+func (mr *MockArticlesApiClientMockRecorder) GetLegacyBulletin(ctx, userAccessToken, collectionID, lang, uri interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBulletin", reflect.TypeOf((*MockZebedeeClient)(nil).GetBulletin), ctx, userAccessToken, lang, uri)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLegacyBulletin", reflect.TypeOf((*MockArticlesApiClient)(nil).GetLegacyBulletin), ctx, userAccessToken, collectionID, lang, uri)
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/articles"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	coreModel "github.com/ONSdigital/dp-renderer/model"
 )
@@ -63,7 +64,7 @@ type Message struct {
 	URI      string `json:"uri"`
 }
 
-func CreateBulletinModel(basePage coreModel.Page, bulletin zebedee.Bulletin, bcs []zebedee.Breadcrumb) BulletinModel {
+func CreateBulletinModel(basePage coreModel.Page, bulletin articles.Bulletin, bcs []zebedee.Breadcrumb) BulletinModel {
 	model := BulletinModel{
 		Page: basePage,
 	}

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/articles"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	coreModel "github.com/ONSdigital/dp-renderer/model"
 
@@ -14,7 +15,8 @@ func TestUnitMapper(t *testing.T) {
 
 	Convey("Given a bulletin, basePage and breadcrumbs", t, func() {
 		basePage := coreModel.NewPage("path/to/assets", "site-domain")
-		bulletin := zebedee.Bulletin{
+
+		bulletin := articles.Bulletin{
 			Description: zebedee.Description{
 				Title:             "Title",
 				Edition:           "2021",

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/articles"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-frontend-articles-controller/config"
 	"github.com/ONSdigital/dp-frontend-articles-controller/handlers"
@@ -17,11 +18,12 @@ type Clients struct {
 	HealthCheckHandler func(w http.ResponseWriter, req *http.Request)
 	Zebedee            *zebedee.Client
 	Render             *render.Render
+	ArticlesAPI        *articles.Client
 }
 
 // Setup registers routes for the service
 func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients) {
 	log.Info(ctx, "adding routes")
 	r.StrictSlash(true).Path("/health").HandlerFunc(c.HealthCheckHandler)
-	r.StrictSlash(true).Path("/{uri:.*}").Methods("GET").HandlerFunc(handlers.Bulletin(*cfg, c.Render, c.Zebedee))
+	r.StrictSlash(true).Path("/{uri:.*}").Methods("GET").HandlerFunc(handlers.Bulletin(*cfg, c.Render, c.Zebedee, c.ArticlesAPI))
 }

--- a/service/service.go
+++ b/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/ONSdigital/dp-api-clients-go/v2/articles"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-frontend-articles-controller/assets"
 	"github.com/ONSdigital/dp-frontend-articles-controller/config"
@@ -47,8 +48,9 @@ func (svc *Service) Init(ctx context.Context, cfg *config.Config, serviceList *E
 
 	// Initialise clients
 	clients := routes.Clients{
-		Render:  render.NewWithDefaultClient(assets.Asset, assets.AssetNames, cfg.PatternLibraryAssetsPath, cfg.SiteDomain),
-		Zebedee: zebedee.NewWithHealthClient(routerHealthClient),
+		Render:      render.NewWithDefaultClient(assets.Asset, assets.AssetNames, cfg.PatternLibraryAssetsPath, cfg.SiteDomain),
+		Zebedee:     zebedee.NewWithHealthClient(routerHealthClient),
+		ArticlesAPI: articles.NewWithHealthClient(routerHealthClient),
 	}
 
 	// Get healthcheck with checkers
@@ -136,6 +138,11 @@ func (svc *Service) registerCheckers(ctx context.Context, c routes.Clients) (err
 	if err = svc.HealthCheck.AddCheck("Zebedee", c.Zebedee.Checker); err != nil {
 		hasErrors = true
 		log.Error(ctx, "failed to add Zebedee checker", err)
+	}
+
+	if err = svc.HealthCheck.AddCheck("Articles API", c.ArticlesAPI.Checker); err != nil {
+		hasErrors = true
+		log.Error(ctx, "failed to add articles API checker", err)
 	}
 
 	if hasErrors {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -113,7 +113,7 @@ func TestInitSuccess(t *testing.T) {
 
 						Convey("And the checkers are registered and the healthcheck", func() {
 							So(mockServiceList.HealthCheck, ShouldBeTrue)
-							So(len(hcMock.AddCheckCalls()), ShouldEqual, 1)
+							So(len(hcMock.AddCheckCalls()), ShouldEqual, 2)
 							So(len(initMock.DoGetHTTPServerCalls()), ShouldEqual, 1)
 							So(initMock.DoGetHTTPServerCalls()[0].BindAddr, ShouldEqual, ":26500")
 						})
@@ -198,8 +198,9 @@ func TestInitFailure(t *testing.T) {
 
 						Convey("And all checks try to register", func() {
 							So(mockServiceList.HealthCheck, ShouldBeTrue)
-							So(len(hcMockAddFail.AddCheckCalls()), ShouldEqual, 1)
+							So(len(hcMockAddFail.AddCheckCalls()), ShouldEqual, 2)
 							So(hcMockAddFail.AddCheckCalls()[0].Name, ShouldResemble, "Zebedee")
+							So(hcMockAddFail.AddCheckCalls()[1].Name, ShouldResemble, "Articles API")
 						})
 					})
 				})


### PR DESCRIPTION
### What

Use the new articles API (and its `legacy` endpoint) instead of Zebedee to read bulletin data

### How to review

Check code is correct and has enough test coverage.
Check tests pass.

Optionally run it:
- Run the latest versions of `zebedee`, `dp-articles-api` and `dp-api-router` (Note Zebedee is still required to read breadcrumbs)
- `make debug`
- Navigate to a valid bulletin URL ([example 1](http://localhost:26500/economy/environmentalaccounts/bulletins/ukenvironmentalaccounts/2015-07-09), [example 2](http://localhost:26500/peoplepopulationandcommunity/housing/bulletins/indexofprivatehousingrentalprices/2015-01-30)) and check it displays data. 
-  Stop `dp-articles-api` and reload the page: an error happens

### Who can review

Anyone 
