### PR TITLE
Add tag to component test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ convey:
 	goconvey ./...
 
 .PHONY: test-component
-test-component:
-	go test -cover -coverpkg=github.com/ONSdigital/dp-frontend-articles-controller/... -component
+test-component: generate-prod
+	go test -cover -tags 'production' -coverpkg=github.com/ONSdigital/dp-frontend-articles-controller/... -component
 
 .PHONY: generate-debug
 generate-debug: fetch-dp-renderer


### PR DESCRIPTION
### What

Fix the `test-component` target which was missing the tag and failed to locate assets

### How to review

Check component tests run in CI and locally via `make test-component`

### Who can review

Anyone
