### PR TITLE
Feature/scaffold bulletin template

### DIFF
--- a/assets/templates/bulletin.tmpl
+++ b/assets/templates/bulletin.tmpl
@@ -1,1 +1,10 @@
-<h1>{{ localise "ReleaseDate" .Language 1 }}</h1>
+<div class="ons-page__container ons-container bulletin">
+  {{ template "partials/breadcrumb" . }}
+
+  <h1 class="ons-u-fs-xxxl ons-u-mt-s">
+    {{- .Page.Metadata.Title -}}
+  </h1>
+
+  {{ template "partials/bulletin/status-header" . }}
+  {{ template "partials/bulletin/contents" . }}
+</div>

--- a/assets/templates/partials/bulletin/contents.tmpl
+++ b/assets/templates/partials/bulletin/contents.tmpl
@@ -1,0 +1,17 @@
+<div class="ons-grid ons-js-toc-container ons-u-ml-no">
+  <!-- Left column -->
+  <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m ons-u-p-no">
+    {{ template "partials/table-of-contents" . }}
+    <div class="ons-u-mb-l">
+      <h2 class="ons-u-fs-r--b ons-u-mb-s">Page actions</h2>
+      <div>Share</div>
+      <div>Download</div>
+      <div>Print</div>
+    </div>
+  </div>
+
+  <!-- Right column -->
+  <div class="ons-grid__col ons-col-8@m">
+    {{ template "partials/bulletin/contents/body" . }}
+  </div>
+</div>

--- a/assets/templates/partials/bulletin/contents/body.tmpl
+++ b/assets/templates/partials/bulletin/contents/body.tmpl
@@ -1,0 +1,13 @@
+<div class="ons-pl-grid-col">
+  <div class="ons-u-mb-l">
+    <a href="">Read long version</a>
+  </div>
+  {{ $bulletin := . }}
+  {{ $sections := .TableOfContents.Sections }}
+  {{ range $id := .TableOfContents.DisplayOrder }}
+    {{ $section := index $sections $id }}
+    <section id="{{ $id }}">
+      <h2>{{ $section.Title.FuncLocalise $.Language }}</h2>
+    </section>
+  {{ end }}
+</div>

--- a/assets/templates/partials/bulletin/status-header.tmpl
+++ b/assets/templates/partials/bulletin/status-header.tmpl
@@ -1,0 +1,19 @@
+<div class="ons-u-mb-xl">
+  <div class="ons-grid ons-u-ml-no">
+    <!-- Left column -->
+    <div class="ons-grid__col ons-col-4@m ons-u-p-no">
+      <div class="ons-pl-grid-col">
+        <span class="ons-u-fs-r--b">Released:</span>
+        <span>{{ dateTimeOnsDatePatternFormat .ReleaseDate }}</span>
+      </div>
+    </div>
+
+    <!-- Right column -->
+    <div class="ons-grid__col ons-col-8@m">
+      <div class="ons-pl-grid-col">
+        <span class="ons-u-fs-r--b">LATEST</span>
+        <a href="">View previous releases</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -326,9 +327,44 @@ func CreateBulletinModel(basePage coreModel.Page, bulletin articles.Bulletin, bc
 		})
 	}
 
+	// TODO: model.Accordion?
+	model.TableOfContents = createTableOfContents(model.Sections)
+
 	return model
 }
 
 func parentPath(p string) string {
 	return p[:strings.LastIndex(p, "/")]
+}
+
+func createTableOfContents(documentSections []Section) coreModel.TableOfContents {
+	toc := coreModel.TableOfContents{
+		AriaLabel: coreModel.Localisation{
+			LocaleKey: "TableOfContents",
+			Plural:    1,
+		},
+		Title: coreModel.Localisation{
+			LocaleKey: "Contents",
+			Plural:    1,
+		},
+	}
+
+	sections := make(map[string]coreModel.ContentSection)
+	displayOrder := make([]string, 0)
+
+	for sectionIndex, section := range documentSections {
+		sectionId := fmt.Sprintf("section-%d", sectionIndex)
+		sections[sectionId] = coreModel.ContentSection{
+			Current: false,
+			Title: coreModel.Localisation{
+				Text: section.Title,
+			},
+		}
+		displayOrder = append(displayOrder, sectionId)
+	}
+
+	toc.Sections = sections
+	toc.DisplayOrder = displayOrder
+
+	return toc
 }


### PR DESCRIPTION
### What

Scaffolds out the top, left, and right portions of the bulletin template.

Anything that works is purely coincidental - every segment of the page and the components within will be revisited individually in greater detail in subsequent PRs.

![bulletin-scaffold](https://user-images.githubusercontent.com/912770/168334941-f7ab8d65-de7d-4616-a480-edec2c0433d8.png)

### How to review

- In a separate shell run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Visit `http://localhost:26500/economy/grossdomesticproductgdp/bulletins/gdpmonthlyestimateuk/august2019`
- Confirm that the document is displayed per the screenshot attached

### Who can review

Frontend / Design System developers
