### PR TITLE
Enable beta banner while under development

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -203,6 +203,7 @@ func CreateBulletinModel(basePage coreModel.Page, bulletin articles.Bulletin, bc
 		Page: basePage,
 	}
 	model.Language = lang
+	model.BetaBannerEnabled = true
 
 	model.Metadata = coreModel.Metadata{
 		Title:       bulletin.Description.Title,

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -461,6 +461,7 @@ func TestUnitMapper(t *testing.T) {
 
 				So(model.Page.PatternLibraryAssetsPath, ShouldEqual, basePage.PatternLibraryAssetsPath)
 				So(model.Page.SiteDomain, ShouldEqual, basePage.SiteDomain)
+				So(model.BetaBannerEnabled, ShouldBeTrue)
 				So(model.Metadata.Title, ShouldEqual, bulletin.Description.Title)
 				So(model.Metadata.Description, ShouldEqual, bulletin.Description.MetaDescription)
 				So(model.Metadata.Keywords, ShouldResemble, bulletin.Description.Keywords)


### PR DESCRIPTION
### What

Beta banner enabled while Design System front end is under development

![Screenshot 2022-05-23 at 12 18 13](https://user-images.githubusercontent.com/912770/169808124-074972da-3454-403e-b928-24dfb141bb9c.png)

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Visit an article e.g. http://localhost:26500/economy/grossdomesticproductgdp/bulletins/gdpmonthlyestimateuk/august2019

### Who can review

Anyone
