### PR TITLE
Translate Home crumb if present

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -106,3 +106,9 @@ other = "Notices"
 description = "Correction"
 one = "Correction"
 other = "Corrections"
+
+#-- ONS Design System
+
+[BreadcrumbHome]
+description = "Home"
+one = "Hafan"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -106,3 +106,9 @@ other = "Notices"
 description = "Correction"
 one = "Correction"
 other = "Corrections"
+
+#-- ONS Design System
+
+[BreadcrumbHome]
+description = "Home"
+one = "Home"

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/articles"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
+	"github.com/ONSdigital/dp-renderer/helper"
 	coreModel "github.com/ONSdigital/dp-renderer/model"
 )
 
@@ -320,12 +321,7 @@ func CreateBulletinModel(basePage coreModel.Page, bulletin articles.Bulletin, bc
 	}
 	sort.Slice(model.Alerts, func(i, j int) bool { return model.Alerts[i].Date > model.Alerts[j].Date })
 
-	for _, bc := range bcs {
-		model.Page.Breadcrumb = append(model.Page.Breadcrumb, coreModel.TaxonomyNode{
-			Title: bc.Description.Title,
-			URI:   bc.URI,
-		})
-	}
+	model.Page.Breadcrumb = mapBreadcrumbTrail(bcs, model.Language)
 
 	// TODO: model.Accordion?
 	model.TableOfContents = createTableOfContents(model.Sections)
@@ -367,4 +363,21 @@ func createTableOfContents(documentSections []Section) coreModel.TableOfContents
 	toc.DisplayOrder = displayOrder
 
 	return toc
+}
+
+func mapBreadcrumbTrail(crumbs []zebedee.Breadcrumb, language string) []coreModel.TaxonomyNode {
+	trail := []coreModel.TaxonomyNode{}
+
+	for _, crumb := range crumbs {
+		trail = append(trail, coreModel.TaxonomyNode{
+			Title: crumb.Description.Title,
+			URI:   crumb.URI,
+		})
+	}
+
+	if len(trail) > 0 && trail[0].Title == "Home" {
+		trail[0].Title = helper.Localise("BreadcrumbHome", language, 1)
+	}
+
+	return trail
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -6,13 +6,15 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/articles"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
+	"github.com/ONSdigital/dp-frontend-articles-controller/mocks"
+	"github.com/ONSdigital/dp-renderer/helper"
 	coreModel "github.com/ONSdigital/dp-renderer/model"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestUnitMapper(t *testing.T) {
-
+	helper.InitialiseLocalisationsHelper(mocks.MockAssetFunction)
 	Convey("Given a bulletin, basePage and breadcrumbs", t, func() {
 		basePage := coreModel.NewPage("path/to/assets", "site-domain")
 
@@ -506,7 +508,11 @@ func TestUnitMapper(t *testing.T) {
 				So(len(model.Breadcrumb), ShouldEqual, len(breadcrumbs))
 				for i, b := range breadcrumbs {
 					found := model.Breadcrumb[i]
-					So(found.Title, ShouldEqual, b.Description.Title)
+					if i == 0 && b.Description.Title == "Home" {
+						So(found.Title, ShouldEqual, "Hafan")
+					} else {
+						So(found.Title, ShouldEqual, b.Description.Title)
+					}
 					So(found.URI, ShouldEqual, b.URI)
 				}
 			})
@@ -562,7 +568,11 @@ func TestUnitMapper(t *testing.T) {
 				So(len(model.Breadcrumb), ShouldEqual, len(breadcrumbs))
 				for i, b := range breadcrumbs {
 					found := model.Breadcrumb[i]
-					So(found.Title, ShouldEqual, b.Description.Title)
+					if i == 0 && b.Description.Title == "Home" {
+						So(found.Title, ShouldEqual, "Hafan")
+					} else {
+						So(found.Title, ShouldEqual, b.Description.Title)
+					}
 					So(found.URI, ShouldEqual, b.URI)
 				}
 			})

--- a/mocks/mock_assets.go
+++ b/mocks/mock_assets.go
@@ -1,0 +1,20 @@
+package mocks
+
+import "strings"
+
+var cyLocale = []string{
+	"[BreadcrumbHome]",
+	"one=\"Hafan\"",
+}
+
+var enLocale = []string{
+	"[BreadcrumbHome]",
+	"one=\"Home\"",
+}
+
+func MockAssetFunction(name string) ([]byte, error) {
+	if strings.Contains(name, ".cy.toml") {
+		return []byte(strings.Join(cyLocale, "\n")), nil
+	}
+	return []byte(strings.Join(enLocale, "\n")), nil
+}


### PR DESCRIPTION
### What

Make a best effort attempt to localise what is likely to be the "Home" breadcrumb, as all other crumbs are arbitrary and supplied by Zebedee.

English:
<img width="383" alt="Screenshot 2022-05-23 at 16 18 11" src="https://user-images.githubusercontent.com/912770/169855383-546564f5-672b-4405-8cb5-37432a51f060.png">

Welsh:
<img width="394" alt="Screenshot 2022-05-23 at 16 18 00" src="https://user-images.githubusercontent.com/912770/169855390-8bc5e892-d047-470d-b840-74e81452be7c.png">

### How to review

- In a separate shell run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Visit an article, for example http://localhost:26500/economy/grossdomesticproductgdp/bulletins/gdpmonthlyestimateuk/august2019
- Confirm that switching between English and Welsh localises the "Home" breadcrumb accordingly

### Who can review

Frontend / Design System developers
