### PR TITLE
Detect and display document type above document title

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -112,3 +112,11 @@ other = "Corrections"
 [BreadcrumbHome]
 description = "Home"
 one = "Hafan"
+
+[DocumentTypeArticle]
+description = "Article"
+one = "Erthygl"
+
+[DocumentTypeBulletin]
+description = "Bulletin"
+one = "Bwletin"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -112,3 +112,11 @@ other = "Corrections"
 [BreadcrumbHome]
 description = "Home"
 one = "Home"
+
+[DocumentTypeArticle]
+description = "Article"
+one = "Article"
+
+[DocumentTypeBulletin]
+description = "Bulletin"
+one = "Bulletin"

--- a/assets/templates/bulletin.tmpl
+++ b/assets/templates/bulletin.tmpl
@@ -1,7 +1,15 @@
 <div class="ons-page__container ons-container bulletin">
   {{ template "partials/breadcrumb" . }}
 
-  <h1 class="ons-u-fs-xxxl ons-u-mt-s ons-u-mb-m">
+  <div class="ons-u-fs-m ons-u-mt-s ons-u-pb-xxs bulletin__document-type">
+    {{- if eq .Type "article" -}}
+      {{- localise "DocumentTypeArticle" .Language 1 -}}
+    {{- else -}}
+      {{- localise "DocumentTypeBulletin" .Language 1 -}}
+    {{- end -}}
+  </div>
+
+  <h1 class="ons-u-fs-xxxl ons-u-mb-m">
     {{- .Page.Metadata.Title -}}
   </h1>
 

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/778ac19"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/4c93148"
 	}
 	return cfg, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.BindAddr, ShouldEqual, ":26500")
 				So(cfg.Debug, ShouldBeFalse)
 				So(cfg.SiteDomain, ShouldEqual, "localhost")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/778ac19")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/4c93148")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -205,7 +205,7 @@ func CreateBulletinModel(basePage coreModel.Page, bulletin articles.Bulletin, bc
 	}
 	model.Language = lang
 	model.BetaBannerEnabled = true
-
+	model.Type = bulletin.Type
 	model.Metadata = coreModel.Metadata{
 		Title:       bulletin.Description.Title,
 		Description: bulletin.Description.MetaDescription,

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -298,6 +298,7 @@ func TestUnitMapper(t *testing.T) {
 		basePage := coreModel.NewPage("path/to/assets", "site-domain")
 
 		bulletin := articles.Bulletin{
+			Type: "bulletin",
 			Description: zebedee.Description{
 				Title:             "Title",
 				Edition:           "2021",


### PR DESCRIPTION
### What

The document type (`article` or `bulletin`) is localised and displayed above the document title.

English:

<img width="697" alt="Screenshot 2022-05-24 at 16 03 23" src="https://user-images.githubusercontent.com/912770/170469143-595671f1-ea26-4710-a84c-640df598a3cf.png">

Welsh:

<img width="719" alt="Screenshot 2022-05-24 at 16 02 52" src="https://user-images.githubusercontent.com/912770/170469154-ac245b1f-fa9a-4863-ba12-266bd6c73aef.png">

### How to review

- In a separate shell, run the dp-design-system with `make debug`
- Run this frontend controller with `make debug`
- Navigate to a known bulletin or article, for example http://localhost:26500/economy/grossdomesticproductgdp/bulletins/gdpmonthlyestimateuk/august2019
- Verify that the document type shown matches the type of the document
- Verify that the document type localises correctly

### Who can review

Frontend / design system developers
