### PR TITLE
Localise timestamp label and previous releases link

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -112,3 +112,11 @@ other = "Corrections"
 [BreadcrumbHome]
 description = "Home"
 one = "Hafan"
+
+[StatusLineReleased]
+description = "Released"
+one = "Rhyddhawyd"
+
+[StatusLinePreviousReleases]
+description = "View previous releases"
+one = "Gweld datganiadau blaenorol"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -112,3 +112,11 @@ other = "Corrections"
 [BreadcrumbHome]
 description = "Home"
 one = "Home"
+
+[StatusLineReleased]
+description = "Released"
+one = "Released"
+
+[StatusLinePreviousReleases]
+description = "View previous releases"
+one = "View previous releases"

--- a/assets/templates/partials/bulletin/status-header.tmpl
+++ b/assets/templates/partials/bulletin/status-header.tmpl
@@ -3,7 +3,7 @@
     <!-- Left column -->
     <div class="ons-grid__col ons-col-4@m ons-u-p-no">
       <div class="ons-pl-grid-col">
-        <span class="ons-u-fs-r--b">Released:</span>
+        <span class="ons-u-fs-r--b">{{ localise "StatusLineReleased" .Language 1 }}:</span>
         <span>{{ dateTimeOnsDatePatternFormat .ReleaseDate }}</span>
       </div>
     </div>
@@ -12,7 +12,7 @@
     <div class="ons-grid__col ons-col-8@m">
       <div class="ons-pl-grid-col">
         <span class="ons-u-fs-r--b">LATEST</span>
-        <a href="">View previous releases</a>
+        <a href="">{{ localise "StatusLinePreviousReleases" .Language 1 }}</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What

Localise timestamp label ("Released") and previous releases link ("View previous releases")

English

<img width="751" alt="Screenshot 2022-05-27 at 15 38 30" src="https://user-images.githubusercontent.com/912770/170721645-607ece5b-8e61-4e29-a232-9efda5f17a45.png">

Welsh

<img width="736" alt="Screenshot 2022-05-27 at 15 37 15" src="https://user-images.githubusercontent.com/912770/170721654-d978932d-e15c-4edb-bb45-5f59103ad13a.png">

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend controller with `make debug`
- Switch locales with `lang` cookie set to `en` or `cy`
- Verify that the label and link are localised

### Who can review

Frontend / design system developers
