### PR TITLE
Localise timestamps with dp-renderer v1.32.1

### DIFF
--- a/assets/templates/partials/bulletin/status-header.tmpl
+++ b/assets/templates/partials/bulletin/status-header.tmpl
@@ -4,7 +4,7 @@
     <div class="ons-grid__col ons-col-4@m ons-u-p-no">
       <div class="ons-pl-grid-col">
         <span class="ons-u-fs-r--b">{{ localise "StatusLineReleased" .Language 1 }}:</span>
-        <span>{{ dateTimeOnsDatePatternFormat .ReleaseDate }}</span>
+        <span>{{ dateTimeOnsDatePatternFormat .ReleaseDate .Language }}</span>
       </div>
     </div>
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.135.0
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-net v1.4.1
-	github.com/ONSdigital/dp-renderer v1.27.0
+	github.com/ONSdigital/dp-renderer v1.32.1
 	github.com/ONSdigital/log.go/v2 v2.2.0
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/ONSdigital/dp-net v1.4.1/go.mod h1:VK8dah+G0TeVO/Os/w17Rk4WM6hIGmdUXr
 github.com/ONSdigital/dp-net/v2 v2.0.0/go.mod h1:Pv/35rM5tCLYdVdIZ5KoGu2EUXv/87fWTptlVTlS5MY=
 github.com/ONSdigital/dp-net/v2 v2.2.0 h1:EHh7n6pdI82F7Ejmbt30d47NC+hzA/RgD9g8i3by4Tk=
 github.com/ONSdigital/dp-net/v2 v2.2.0/go.mod h1:Pv/35rM5tCLYdVdIZ5KoGu2EUXv/87fWTptlVTlS5MY=
-github.com/ONSdigital/dp-renderer v1.27.0 h1:DE7cZM1lzhv2Bt57BCouX6M8f8jJJThZB3yUXAnr60Y=
-github.com/ONSdigital/dp-renderer v1.27.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.32.1 h1:OMtq8006DLiRVV2qHkMU1FOVyEYSdBMyN/po2IjTOgE=
+github.com/ONSdigital/dp-renderer v1.32.1/go.mod h1:odKmVudLXN9WaenfrKgGGrfmZARZFemSNtSy6gxTue8=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Localises timestamps in:
- Article status line "Released" date

<img width="1024" alt="Screenshot 2022-06-07 at 19 11 49" src="https://user-images.githubusercontent.com/912770/172453322-67415e13-0bad-41fb-803e-4180ecffce5a.png">

### How to review

How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend controller with `make debug`
- Switch locales with `lang` cookie set to `en` or `cy`
- Verify that the "Released" date is localised

### Who can review

Frontend / design system developers
