### PR TITLE
Article release status and alternative version link

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -125,6 +125,26 @@ one = "Bwletin"
 description = "Released"
 one = "Rhyddhawyd"
 
-[StatusLinePreviousReleases]
+[StatusLineViewPreviousReleases]
 description = "View previous releases"
-one = "Gweld datganiadau blaenorol"
+other = "Gweld datganiadau blaenorol"
+
+[StatusLineViewCorrectedVersion]
+description = "View corrected version"
+one = "View corrected version (cy)"
+
+[StatusLineViewLatestRelease]
+description = "View latest release"
+one = "View latest release (cy)"
+
+[StatusLineReleaseLatest]
+description = "LATEST"
+one = "DIWEDDARAF"
+
+[StatusLineReleaseSuperseded]
+description = "SUPERSEDED"
+one = "SUPERSEDED (cy)"
+
+[StatusLineReleaseOutdated]
+description = "OUTDATED"
+one = "OUTDATED (cy)"

--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -138,13 +138,13 @@ description = "View latest release"
 one = "View latest release (cy)"
 
 [StatusLineReleaseLatest]
-description = "LATEST"
-one = "DIWEDDARAF"
+description = "Latest"
+one = "Diweddaraf"
 
 [StatusLineReleaseSuperseded]
-description = "SUPERSEDED"
-one = "SUPERSEDED (cy)"
+description = "Superseded"
+one = "Superseded (cy)"
 
 [StatusLineReleaseOutdated]
-description = "OUTDATED"
-one = "OUTDATED (cy)"
+description = "Outdated"
+one = "Outdated (cy)"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -138,13 +138,13 @@ description = "View latest release"
 one = "View latest release"
 
 [StatusLineReleaseLatest]
-description = "LATEST"
-one = "LATEST"
+description = "Latest"
+one = "Latest"
 
 [StatusLineReleaseSuperseded]
-description = "SUPERSEDED"
-one = "SUPERSEDED"
+description = "Superseded"
+one = "Superseded"
 
 [StatusLineReleaseOutdated]
-description = "OUTDATED"
-one = "OUTDATED"
+description = "Outdated"
+one = "Outdated"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -125,6 +125,26 @@ one = "Bulletin"
 description = "Released"
 one = "Released"
 
-[StatusLinePreviousReleases]
+[StatusLineViewPreviousReleases]
 description = "View previous releases"
-one = "View previous releases"
+other = "View previous releases"
+
+[StatusLineViewCorrectedVersion]
+description = "View corrected version"
+one = "View corrected version"
+
+[StatusLineViewLatestRelease]
+description = "View latest release"
+one = "View latest release"
+
+[StatusLineReleaseLatest]
+description = "LATEST"
+one = "LATEST"
+
+[StatusLineReleaseSuperseded]
+description = "SUPERSEDED"
+one = "SUPERSEDED"
+
+[StatusLineReleaseOutdated]
+description = "OUTDATED"
+one = "OUTDATED"

--- a/assets/templates/partials/bulletin/status-header.tmpl
+++ b/assets/templates/partials/bulletin/status-header.tmpl
@@ -13,18 +13,18 @@
       <div class="ons-pl-grid-col">
         {{ if .CorrectedPath }}
           {{/* Detect an old version of a release and link to the latest version */}}
-          <span class="ons-u-fs-r--b">{{ localise "StatusLineReleaseSuperseded" .Language 1 }}</span>
+          <span class="ons-u-fs-r--b ons-u-tt-u">{{ localise "StatusLineReleaseSuperseded" .Language 1 }}</span>
           <a href="{{ .CorrectedPath }}">
             {{- localise "StatusLineViewCorrectedVersion" .Language 1 -}}
           </a>
         {{ else if .LatestRelease }}
-          <span class="ons-u-fs-r--b">{{ localise "StatusLineReleaseLatest" .Language 1 }}</span>
+          <span class="ons-u-fs-r--b ons-u-tt-u">{{ localise "StatusLineReleaseLatest" .Language 1 }}</span>
           <a href="{{ .ParentPath }}/previousReleases">
             {{- localise "StatusLineViewPreviousReleases" .Language 4 -}}
           </a>
         {{ else }}
           {{/* Detect an old edition of a release and link to the latest edition */}}
-          <span class="ons-u-fs-r--b">{{ localise "StatusLineReleaseOutdated" .Language 1 }}</span>
+          <span class="ons-u-fs-r--b ons-u-tt-u">{{ localise "StatusLineReleaseOutdated" .Language 1 }}</span>
           <a href="{{ .LatestReleaseUri }}">
             {{- localise "StatusLineViewLatestRelease" .Language 1 -}}
           </a>

--- a/assets/templates/partials/bulletin/status-header.tmpl
+++ b/assets/templates/partials/bulletin/status-header.tmpl
@@ -12,6 +12,7 @@
     <div class="ons-grid__col ons-col-8@m">
       <div class="ons-pl-grid-col">
         {{ if .CorrectedPath }}
+          {{/* Detect an old version of a release and link to the latest version */}}
           <span class="ons-u-fs-r--b">{{ localise "StatusLineReleaseSuperseded" .Language 1 }}</span>
           <a href="{{ .CorrectedPath }}">
             {{- localise "StatusLineViewCorrectedVersion" .Language 1 -}}
@@ -22,6 +23,7 @@
             {{- localise "StatusLineViewPreviousReleases" .Language 4 -}}
           </a>
         {{ else }}
+          {{/* Detect an old edition of a release and link to the latest edition */}}
           <span class="ons-u-fs-r--b">{{ localise "StatusLineReleaseOutdated" .Language 1 }}</span>
           <a href="{{ .LatestReleaseUri }}">
             {{- localise "StatusLineViewLatestRelease" .Language 1 -}}

--- a/assets/templates/partials/bulletin/status-header.tmpl
+++ b/assets/templates/partials/bulletin/status-header.tmpl
@@ -12,7 +12,7 @@
     <div class="ons-grid__col ons-col-8@m">
       <div class="ons-pl-grid-col">
         <span class="ons-u-fs-r--b">LATEST</span>
-        <a href="">{{ localise "StatusLinePreviousReleases" .Language 1 }}</a>
+        <a href="">{{ localise "StatusLineViewPreviousReleases" .Language 4 }}</a>
       </div>
     </div>
   </div>

--- a/assets/templates/partials/bulletin/status-header.tmpl
+++ b/assets/templates/partials/bulletin/status-header.tmpl
@@ -11,8 +11,22 @@
     <!-- Right column -->
     <div class="ons-grid__col ons-col-8@m">
       <div class="ons-pl-grid-col">
-        <span class="ons-u-fs-r--b">LATEST</span>
-        <a href="">{{ localise "StatusLineViewPreviousReleases" .Language 4 }}</a>
+        {{ if .CorrectedPath }}
+          <span class="ons-u-fs-r--b">{{ localise "StatusLineReleaseSuperseded" .Language 1 }}</span>
+          <a href="{{ .CorrectedPath }}">
+            {{- localise "StatusLineViewCorrectedVersion" .Language 1 -}}
+          </a>
+        {{ else if .LatestRelease }}
+          <span class="ons-u-fs-r--b">{{ localise "StatusLineReleaseLatest" .Language 1 }}</span>
+          <a href="{{ .ParentPath }}/previousReleases">
+            {{- localise "StatusLineViewPreviousReleases" .Language 4 -}}
+          </a>
+        {{ else }}
+          <span class="ons-u-fs-r--b">{{ localise "StatusLineReleaseOutdated" .Language 1 }}</span>
+          <a href="{{ .LatestReleaseUri }}">
+            {{- localise "StatusLineViewLatestRelease" .Language 1 -}}
+          </a>
+        {{ end }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What

The article's release status (latest, superseded, or outdated) is indicated alongside a relevant link to other versions from the perspective of the version being displayed.

<img width="720" alt="Screenshot 2022-06-27 at 15 29 54" src="https://user-images.githubusercontent.com/912770/175965898-032ba56f-9741-4199-9cd2-92d5bef99238.png">
<img width="734" alt="Screenshot 2022-06-27 at 15 29 36" src="https://user-images.githubusercontent.com/912770/175965789-3c807ae0-ee8d-4e18-9998-d7a11b33c883.png">
<img width="746" alt="Screenshot 2022-06-27 at 15 29 05" src="https://user-images.githubusercontent.com/912770/175965796-66fde027-68db-4b59-8271-adb541af9b70.png">

### How to review

- In a separate shell, run the dp-design-system with `make debug`
- Run this frontend with `make debug`
- View different versions of article to verify that the appropriate version status and link are shown

### Who can review

Front end / design system developers
