### PR TITLE
Add timezone support to deployed image

### DIFF
--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -1,5 +1,7 @@
 FROM onsdigital/dp-concourse-tools-ubuntu
 
+RUN apt-get update && apt-get install tzdata
+
 WORKDIR /app/
 
 COPY dp-frontend-articles-controller .


### PR DESCRIPTION
### What

Go's `time.LoadLocation()` will fail to find a timezone like `Europe/London` and interpret timestamps accordingly unless timezone definitions are installed on the OS.

### How to review

Sense check

### Who can review

Go devs / Devops
