### PR TITLE
Add basic list of page actions for further development

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -128,3 +128,31 @@ one = "Rhyddhawyd"
 [StatusLinePreviousReleases]
 description = "View previous releases"
 one = "Gweld datganiadau blaenorol"
+
+[PageActionsTitle]
+description = "Gweithredoedd y dudalen"
+other = "Gweithredoedd y dudalen"
+
+[PageActionTweet]
+description = "Tweet"
+one = "Trydariad"
+
+[PageActionLinkedIn]
+description = "LinkedIn"
+one = "LinkedIn"
+
+[PageActionEmail]
+description = "Email"
+one = "E-bost"
+
+[PageActionCopyLink]
+description = "Copy link"
+one = "Copïo'r ddolen"
+
+[PageActionDownloadPDF]
+description = "Download PDF"
+one = "Lawrlwytho fel PDF"
+
+[PageActionPrint]
+description = "Print"
+one = "Argraffu"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -128,3 +128,31 @@ one = "Released"
 [StatusLinePreviousReleases]
 description = "View previous releases"
 one = "View previous releases"
+
+[PageActionsTitle]
+description = "Page actions"
+other = "Page actions"
+
+[PageActionTweet]
+description = "Tweet"
+one = "Tweet"
+
+[PageActionLinkedIn]
+description = "LinkedIn"
+one = "LinkedIn"
+
+[PageActionEmail]
+description = "Email"
+one = "Email"
+
+[PageActionCopyLink]
+description = "Copy link"
+one = "Copy link"
+
+[PageActionDownloadPDF]
+description = "Download PDF"
+one = "Download PDF"
+
+[PageActionPrint]
+description = "Print"
+one = "Print"

--- a/assets/templates/partials/bulletin/contents.tmpl
+++ b/assets/templates/partials/bulletin/contents.tmpl
@@ -2,12 +2,7 @@
   <!-- Left column -->
   <div class="ons-grid__col ons-grid__col--sticky@m ons-col-4@m ons-u-p-no">
     {{ template "partials/table-of-contents" . }}
-    <div class="ons-u-mb-l">
-      <h2 class="ons-u-fs-r--b ons-u-mb-s">Page actions</h2>
-      <div>Share</div>
-      <div>Download</div>
-      <div>Print</div>
-    </div>
+    {{ template "partials/bulletin/page-actions/list" . }}
   </div>
 
   <!-- Right column -->

--- a/assets/templates/partials/bulletin/page-actions/list.tmpl
+++ b/assets/templates/partials/bulletin/page-actions/list.tmpl
@@ -1,0 +1,55 @@
+<aside class="ons-u-mb-l">
+  <h2 class="ons-u-fs-r--b ons-u-mb-s">
+    {{- localise "PageActionsTitle" .Language 4 -}}
+  </h2>
+  <ul class="ons-list ons-list--bare ons-list--icons">
+    <li class="ons-list__item">
+      <span class="ons-list__prefix">
+        {{ template "icons/twitter" }}
+      </span>
+      <a href="">
+        {{- localise "PageActionTweet" .Language 1 -}}
+      </a>
+    </li>
+    <li class="ons-list__item">
+      <span class="ons-list__prefix">
+        {{ template "icons/linkedin" }}
+      </span>
+      <a href="">
+        {{- localise "PageActionLinkedIn" .Language 1 -}}
+      </a>
+    </li>
+    <li class="ons-list__item">
+      <span class="ons-list__prefix">
+        {{ template "icons/email" }}
+      </span>
+      <a href="">
+        {{- localise "PageActionEmail" .Language 1 -}}
+      </a>
+    </li>
+    <li class="ons-list__item">
+      <span class="ons-list__prefix">
+        {{ template "icons/copy-link" }}
+      </span>
+      <a href="">
+        {{- localise "PageActionCopyLink" .Language 1 -}}
+      </a>
+    </li>
+    <li class="ons-list__item">
+      <span class="ons-list__prefix page-action__icon--no-roundel">
+        {{ template "icons/download" }}
+      </span>
+      <a href="{{ .URI }}/pdf">
+        {{- localise "PageActionDownloadPDF" .Language 1 -}}
+      </a>
+    </li>
+    <li class="ons-list__item">
+      <span class="ons-list__prefix page-action__icon--no-roundel">
+        {{ template "icons/print" }}
+      </span>
+      <a href="">
+        {{- localise "PageActionPrint" .Language 1 -}}
+      </a>
+    </li>
+  </ul>
+</aside>

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/4c93148"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/669c762"
 	}
 	return cfg, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.BindAddr, ShouldEqual, ":26500")
 				So(cfg.Debug, ShouldBeFalse)
 				So(cfg.SiteDomain, ShouldEqual, "localhost")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/4c93148")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/669c762")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)


### PR DESCRIPTION
### What

Lists all the page actions available to the user. These are non-functioning placeholders; the behaviour of each hasn't been determined yet.

In this PR:
:green_heart: Icons
:green_heart: Translations

Not in this PR:
:broken_heart: Functioning links
:broken_heart: Final layout

<img width="342" alt="Screenshot 2022-06-29 at 17 08 24" src="https://user-images.githubusercontent.com/912770/176484917-5ed569ae-b149-46ba-acbc-4a51da369275.png">

<img width="346" alt="Screenshot 2022-06-29 at 17 08 14" src="https://user-images.githubusercontent.com/912770/176484930-6e9cde68-00c2-44f0-935c-2ab8fb308e5f.png">

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Verify that the list renders as above, with translations set with the `lang` cookie by `en` or `cy`

### Who can review

Front end / design developers
