### PR TITLE
Import dp-design-system 1.21.0 and style status sticker

### DIFF
--- a/assets/templates/partials/bulletin/status-header.tmpl
+++ b/assets/templates/partials/bulletin/status-header.tmpl
@@ -13,18 +13,24 @@
       <div class="ons-pl-grid-col">
         {{ if .CorrectedPath }}
           {{/* Detect an old version of a release and link to the latest version */}}
-          <span class="ons-u-fs-r--b ons-u-tt-u">{{ localise "StatusLineReleaseSuperseded" .Language 1 }}</span>
+          <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
+            {{- localise "StatusLineReleaseSuperseded" .Language 1 -}}
+          </span>
           <a href="{{ .CorrectedPath }}">
             {{- localise "StatusLineViewCorrectedVersion" .Language 1 -}}
           </a>
         {{ else if .LatestRelease }}
-          <span class="ons-u-fs-r--b ons-u-tt-u">{{ localise "StatusLineReleaseLatest" .Language 1 }}</span>
+          <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
+            {{- localise "StatusLineReleaseLatest" .Language 1 -}}
+          </span>
           <a href="{{ .ParentPath }}/previousReleases">
             {{- localise "StatusLineViewPreviousReleases" .Language 4 -}}
           </a>
         {{ else }}
           {{/* Detect an old edition of a release and link to the latest edition */}}
-          <span class="ons-u-fs-r--b ons-u-tt-u">{{ localise "StatusLineReleaseOutdated" .Language 1 }}</span>
+          <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
+            {{- localise "StatusLineReleaseOutdated" .Language 1 -}}
+          </span>
           <a href="{{ .LatestReleaseUri }}">
             {{- localise "StatusLineViewLatestRelease" .Language 1 -}}
           </a>

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/669c762"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/b6824ed"
 	}
 	return cfg, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.BindAddr, ShouldEqual, ":26500")
 				So(cfg.Debug, ShouldBeFalse)
 				So(cfg.SiteDomain, ShouldEqual, "localhost")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/669c762")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/b6824ed")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)


### PR DESCRIPTION
### What

The status ("outdated" in this example) uses the sticker style.

<img width="695" alt="Screenshot 2022-07-05 at 10 47 03" src="https://user-images.githubusercontent.com/912770/177301935-c022069b-56d9-4a61-aa16-6a5aecb72317.png">

### How to review

- In a separate shell, run the dp-design-system with `make debug`
- Run this frontend with `make debug`
- Verify that the status appears as in the screenshot above

### Who can review

Frontend / design system developers
