### PR TITLE
Sections shown in display order

### DIFF
--- a/assets/templates/partials/bulletin/contents/body.tmpl
+++ b/assets/templates/partials/bulletin/contents/body.tmpl
@@ -2,18 +2,11 @@
   <div class="ons-u-mb-l">
     <a href="">Read long version</a>
   </div>
-  {{ range $tocSectionId := .TableOfContents.DisplayOrder }}
-    {{ $tocSection := index $.TableOfContents.Sections $tocSectionId }}
-    <section id="{{ $tocSectionId }}">
-      <h2>{{ $tocSection.Title.FuncLocalise $.Language }}</h2>
-      {{ $sectionRef := $.FuncLookupSection $tocSectionId }}
-      {{ if eq $sectionRef.Type "section" }}
-        {{ $content := index $.Sections $sectionRef.Index }}
-        {{ markdown $content.Markdown }}
-      {{ else if eq $sectionRef.Type "accordion" }}
-        {{ $content := index $.Accordion $sectionRef.Index }}
-        {{ markdown $content.Markdown }}
-      {{ end }}
+  {{ range $sectionView := .ContentsView }}
+    <section id="{{ $sectionView.Id }}">
+      {{ $content := index $sectionView.Source $sectionView.Index }}
+      <h2>{{ $content.Title }}</h2>
+      {{ markdown $content.Markdown }}
     </section>
   {{ end }}
 </div>

--- a/assets/templates/partials/bulletin/contents/body.tmpl
+++ b/assets/templates/partials/bulletin/contents/body.tmpl
@@ -2,12 +2,18 @@
   <div class="ons-u-mb-l">
     <a href="">Read long version</a>
   </div>
-  {{ $bulletin := . }}
-  {{ $sections := .TableOfContents.Sections }}
-  {{ range $id := .TableOfContents.DisplayOrder }}
-    {{ $section := index $sections $id }}
-    <section id="{{ $id }}">
-      <h2>{{ $section.Title.FuncLocalise $.Language }}</h2>
+  {{ range $tocSectionId := .TableOfContents.DisplayOrder }}
+    {{ $tocSection := index $.TableOfContents.Sections $tocSectionId }}
+    <section id="{{ $tocSectionId }}">
+      <h2>{{ $tocSection.Title.FuncLocalise $.Language }}</h2>
+      {{ $sectionRef := $.FuncLookupSection $tocSectionId }}
+      {{ if eq $sectionRef.Type "section" }}
+        {{ $content := index $.Sections $sectionRef.Index }}
+        {{ markdown $content.Markdown }}
+      {{ else if eq $sectionRef.Type "accordion" }}
+        {{ $content := index $.Accordion $sectionRef.Index }}
+        {{ markdown $content.Markdown }}
+      {{ end }}
     </section>
   {{ end }}
 </div>

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -1,7 +1,6 @@
 package mapper
 
 import (
-	"fmt"
 	"sort"
 	"testing"
 
@@ -544,6 +543,7 @@ func TestUnitMapper(t *testing.T) {
 				So(len(model.Sections), ShouldEqual, len(bulletin.Sections))
 				assertSections(model.Sections, bulletin.Sections)
 				assertSections(model.Accordion, bulletin.Accordion)
+				assertContentsView(model.ContentsView, bulletin.Sections, bulletin.Accordion)
 				assertLinks(model.RelatedBulletins, bulletin.RelatedBulletins)
 				assertLinks(model.RelatedData, bulletin.RelatedData)
 				assertLinks(model.Links, bulletin.Links)
@@ -581,50 +581,18 @@ func TestUnitMapper(t *testing.T) {
 			})
 		})
 	})
+}
 
-	Convey("FuncLookupSection", t, func() {
-		basePage := coreModel.NewPage("path/to/assets", "site-domain")
-
-		Convey("Should detect a normal section", func() {
-			model := BulletinModel{
-				Page: basePage,
-			}
-
-			sectionType := "section"
-			sectionIndex := 10
-			id := fmt.Sprintf("%s-%d", sectionType, sectionIndex)
-			ref, err := model.FuncLookupSection(id)
-
-			So(err, ShouldBeNil)
-			So(ref.Type, ShouldEqual, sectionType)
-			So(ref.Index, ShouldEqual, sectionIndex)
-		})
-
-		Convey("Should detect an accordion section", func() {
-			model := BulletinModel{
-				Page: basePage,
-			}
-
-			sectionType := "accordion"
-			sectionIndex := 10
-			id := fmt.Sprintf("%s-%d", sectionType, sectionIndex)
-			ref, err := model.FuncLookupSection(id)
-
-			So(err, ShouldBeNil)
-			So(ref.Type, ShouldEqual, sectionType)
-			So(ref.Index, ShouldEqual, sectionIndex)
-		})
-
-		Convey("Should return an error otherwise", func() {
-			model := BulletinModel{
-				Page: basePage,
-			}
-
-			_, err := model.FuncLookupSection("mystery-10")
-
-			So(err, ShouldBeError)
-		})
-	})
+func assertContentsView(found []ViewSection, expectedSections, expectedAccordion []zebedee.Section) {
+	totalSections := len(expectedSections)
+	totalAccordions := len(expectedAccordion)
+	So(len(found), ShouldEqual, totalSections+totalAccordions)
+	for i := range expectedSections {
+		So(found[i].Type, ShouldEqual, "section")
+	}
+	for i := range expectedAccordion {
+		So(found[totalAccordions+i].Type, ShouldEqual, "accordion")
+	}
 }
 
 func assertSections(found []Section, expected []zebedee.Section) {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -1,6 +1,7 @@
 package mapper
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -578,6 +579,50 @@ func TestUnitMapper(t *testing.T) {
 					So(found.URI, ShouldEqual, b.URI)
 				}
 			})
+		})
+	})
+
+	Convey("FuncLookupSection", t, func() {
+		basePage := coreModel.NewPage("path/to/assets", "site-domain")
+
+		Convey("Should detect a normal section", func() {
+			model := BulletinModel{
+				Page: basePage,
+			}
+
+			sectionType := "section"
+			sectionIndex := 10
+			id := fmt.Sprintf("%s-%d", sectionType, sectionIndex)
+			ref, err := model.FuncLookupSection(id)
+
+			So(err, ShouldBeNil)
+			So(ref.Type, ShouldEqual, sectionType)
+			So(ref.Index, ShouldEqual, sectionIndex)
+		})
+
+		Convey("Should detect an accordion section", func() {
+			model := BulletinModel{
+				Page: basePage,
+			}
+
+			sectionType := "accordion"
+			sectionIndex := 10
+			id := fmt.Sprintf("%s-%d", sectionType, sectionIndex)
+			ref, err := model.FuncLookupSection(id)
+
+			So(err, ShouldBeNil)
+			So(ref.Type, ShouldEqual, sectionType)
+			So(ref.Index, ShouldEqual, sectionIndex)
+		})
+
+		Convey("Should return an error otherwise", func() {
+			model := BulletinModel{
+				Page: basePage,
+			}
+
+			_, err := model.FuncLookupSection("mystery-10")
+
+			So(err, ShouldBeError)
 		})
 	})
 }


### PR DESCRIPTION
### What

- Displaying the sections that make up the body of an article (or bulletin) is governed by the order in the Table of Contents.
- What Florence refers to as "collapsible" sections are always displayed after conventional sections, just as Babbage would render them.

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Visit http://localhost:26500/economy/economicoutputandproductivity/output/articles/foo1119/something and verify that the above changes are true

### Who can review

Frontend / design system developers
