### PR TITLE
Mobile and desktop layout for status line

### DIFF
--- a/assets/templates/partials/bulletin/status-header.tmpl
+++ b/assets/templates/partials/bulletin/status-header.tmpl
@@ -1,9 +1,12 @@
 <ul class="ons-list ons-list--bare ons-list--inline ons-u-mb-xl">
-  <li class="ons-list__item ons-u-mr-xs@xs ons-u-mb-xs@xxs@m">
+  <li class="ons-list__item ons-u-mr-xs@xs">
     <span class="ons-u-fs-r--b">{{ localise "StatusLineReleased" .Language 1 }}:</span>
     <span class="ons-u-nowrap">{{ dateTimeOnsDatePatternFormat .ReleaseDate .Language }}</span>
   </li>
-  <li class="ons-list__item">
-    {{ template "partials/bulletin/status-header/edition-version" . }}
+  <li class="ons-list__item ons-u-mt-xs@xxs@m ons-u-mr-s@xxs@m ons-u-mr-l@m">
+    {{ template "partials/bulletin/status-header/edition-version-sticker" . }}
+  </li>
+  <li class="ons-list__item ons-u-mt-xs@xxs@m">
+    {{ template "partials/bulletin/status-header/edition-version-link" . }}
   </li>
 </ul>

--- a/assets/templates/partials/bulletin/status-header.tmpl
+++ b/assets/templates/partials/bulletin/status-header.tmpl
@@ -11,30 +11,7 @@
     <!-- Right column -->
     <div class="ons-grid__col ons-col-8@m">
       <div class="ons-pl-grid-col">
-        {{ if .CorrectedPath }}
-          {{/* Detect an old version of a release and link to the latest version */}}
-          <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
-            {{- localise "StatusLineReleaseSuperseded" .Language 1 -}}
-          </span>
-          <a href="{{ .CorrectedPath }}">
-            {{- localise "StatusLineViewCorrectedVersion" .Language 1 -}}
-          </a>
-        {{ else if .LatestRelease }}
-          <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
-            {{- localise "StatusLineReleaseLatest" .Language 1 -}}
-          </span>
-          <a href="{{ .ParentPath }}/previousReleases">
-            {{- localise "StatusLineViewPreviousReleases" .Language 4 -}}
-          </a>
-        {{ else }}
-          {{/* Detect an old edition of a release and link to the latest edition */}}
-          <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
-            {{- localise "StatusLineReleaseOutdated" .Language 1 -}}
-          </span>
-          <a href="{{ .LatestReleaseUri }}">
-            {{- localise "StatusLineViewLatestRelease" .Language 1 -}}
-          </a>
-        {{ end }}
+        {{ template "partials/bulletin/status-header/edition-version" . }}
       </div>
     </div>
   </div>

--- a/assets/templates/partials/bulletin/status-header.tmpl
+++ b/assets/templates/partials/bulletin/status-header.tmpl
@@ -1,18 +1,9 @@
-<div class="ons-u-mb-xl">
-  <div class="ons-grid ons-u-ml-no">
-    <!-- Left column -->
-    <div class="ons-grid__col ons-col-4@m ons-u-p-no">
-      <div class="ons-pl-grid-col">
-        <span class="ons-u-fs-r--b">{{ localise "StatusLineReleased" .Language 1 }}:</span>
-        <span>{{ dateTimeOnsDatePatternFormat .ReleaseDate .Language }}</span>
-      </div>
-    </div>
-
-    <!-- Right column -->
-    <div class="ons-grid__col ons-col-8@m">
-      <div class="ons-pl-grid-col">
-        {{ template "partials/bulletin/status-header/edition-version" . }}
-      </div>
-    </div>
-  </div>
-</div>
+<ul class="ons-list ons-list--bare ons-list--inline ons-u-mb-xl">
+  <li class="ons-list__item ons-u-mr-xs@xs ons-u-mb-xs@xxs@m">
+    <span class="ons-u-fs-r--b">{{ localise "StatusLineReleased" .Language 1 }}:</span>
+    <span class="ons-u-nowrap">{{ dateTimeOnsDatePatternFormat .ReleaseDate .Language }}</span>
+  </li>
+  <li class="ons-list__item">
+    {{ template "partials/bulletin/status-header/edition-version" . }}
+  </li>
+</ul>

--- a/assets/templates/partials/bulletin/status-header/edition-version-link.tmpl
+++ b/assets/templates/partials/bulletin/status-header/edition-version-link.tmpl
@@ -1,23 +1,14 @@
 {{ if .CorrectedPath }}
   {{/* Detect an old version of a release and link to the latest version */}}
-  <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
-    {{- localise "StatusLineReleaseSuperseded" .Language 1 -}}
-  </span>
   <a class="ons-u-nowrap" href="{{ .CorrectedPath }}">
     {{- localise "StatusLineViewCorrectedVersion" .Language 1 -}}
   </a>
 {{ else if .LatestRelease }}
-  <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
-    {{- localise "StatusLineReleaseLatest" .Language 1 -}}
-  </span>
   <a class="ons-u-nowrap" href="{{ .ParentPath }}/previousReleases">
     {{- localise "StatusLineViewPreviousReleases" .Language 4 -}}
   </a>
 {{ else }}
   {{/* Detect an old edition of a release and link to the latest edition */}}
-  <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
-    {{- localise "StatusLineReleaseOutdated" .Language 1 -}}
-  </span>
   <a class="ons-u-nowrap" href="{{ .LatestReleaseUri }}">
     {{- localise "StatusLineViewLatestRelease" .Language 1 -}}
   </a>

--- a/assets/templates/partials/bulletin/status-header/edition-version-sticker.tmpl
+++ b/assets/templates/partials/bulletin/status-header/edition-version-sticker.tmpl
@@ -1,0 +1,15 @@
+{{ if .CorrectedPath }}
+  {{/* Detect an old version of a release and link to the latest version */}}
+  <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-nowrap">
+    {{- localise "StatusLineReleaseSuperseded" .Language 1 -}}
+  </span>
+{{ else if .LatestRelease }}
+  <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-nowrap">
+    {{- localise "StatusLineReleaseLatest" .Language 1 -}}
+  </span>
+{{ else }}
+  {{/* Detect an old edition of a release and link to the latest edition */}}
+  <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-nowrap">
+    {{- localise "StatusLineReleaseOutdated" .Language 1 -}}
+  </span>
+{{ end }}

--- a/assets/templates/partials/bulletin/status-header/edition-version.tmpl
+++ b/assets/templates/partials/bulletin/status-header/edition-version.tmpl
@@ -1,0 +1,24 @@
+{{ if .CorrectedPath }}
+  {{/* Detect an old version of a release and link to the latest version */}}
+  <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
+    {{- localise "StatusLineReleaseSuperseded" .Language 1 -}}
+  </span>
+  <a href="{{ .CorrectedPath }}">
+    {{- localise "StatusLineViewCorrectedVersion" .Language 1 -}}
+  </a>
+{{ else if .LatestRelease }}
+  <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
+    {{- localise "StatusLineReleaseLatest" .Language 1 -}}
+  </span>
+  <a href="{{ .ParentPath }}/previousReleases">
+    {{- localise "StatusLineViewPreviousReleases" .Language 4 -}}
+  </a>
+{{ else }}
+  {{/* Detect an old edition of a release and link to the latest edition */}}
+  <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
+    {{- localise "StatusLineReleaseOutdated" .Language 1 -}}
+  </span>
+  <a href="{{ .LatestReleaseUri }}">
+    {{- localise "StatusLineViewLatestRelease" .Language 1 -}}
+  </a>
+{{ end }}

--- a/assets/templates/partials/bulletin/status-header/edition-version.tmpl
+++ b/assets/templates/partials/bulletin/status-header/edition-version.tmpl
@@ -3,14 +3,14 @@
   <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
     {{- localise "StatusLineReleaseSuperseded" .Language 1 -}}
   </span>
-  <a href="{{ .CorrectedPath }}">
+  <a class="ons-u-nowrap" href="{{ .CorrectedPath }}">
     {{- localise "StatusLineViewCorrectedVersion" .Language 1 -}}
   </a>
 {{ else if .LatestRelease }}
   <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
     {{- localise "StatusLineReleaseLatest" .Language 1 -}}
   </span>
-  <a href="{{ .ParentPath }}/previousReleases">
+  <a class="ons-u-nowrap" href="{{ .ParentPath }}/previousReleases">
     {{- localise "StatusLineViewPreviousReleases" .Language 4 -}}
   </a>
 {{ else }}
@@ -18,7 +18,7 @@
   <span class="ons-sticker ons-u-fs-s--b ons-u-tt-u ons-u-mr-s@xxs@m ons-u-mr-l@m">
     {{- localise "StatusLineReleaseOutdated" .Language 1 -}}
   </span>
-  <a href="{{ .LatestReleaseUri }}">
+  <a class="ons-u-nowrap" href="{{ .LatestReleaseUri }}">
     {{- localise "StatusLineViewLatestRelease" .Language 1 -}}
   </a>
 {{ end }}


### PR DESCRIPTION
### What

Follow the Figma design for Desktop/Tablet and Mobile, splitting the status line in two on Mobile:

<img width="702" alt="Screenshot 2022-07-06 at 17 02 30" src="https://user-images.githubusercontent.com/912770/177600953-0b32138c-60e6-453d-9641-7869f667a2ac.png">
<img width="374" alt="Screenshot 2022-07-06 at 17 02 15" src="https://user-images.githubusercontent.com/912770/177600963-16d07c2e-89ed-4c8f-b988-7bca681d98d5.png">

In a departure from Figma because no design for this situation yet exists, accommodate longer sticker and link labels by using a third line:

<img width="690" alt="Screenshot 2022-07-06 at 17 35 17" src="https://user-images.githubusercontent.com/912770/177601278-0f437989-2f86-4321-b22a-68d328929ff9.png">
<img width="373" alt="Screenshot 2022-07-06 at 17 35 05" src="https://user-images.githubusercontent.com/912770/177601286-b2506d66-a4cc-4549-91cf-a5594497befe.png">

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Verify that the release date, sticker, and version link are laid out appropriately on each device size 

### Who can review

Frontend / design system developers
