### PR TITLE
Sharing actions (email, twitter, linkedin) implemented

### DIFF
--- a/assets/templates/partials/bulletin/page-actions/list.tmpl
+++ b/assets/templates/partials/bulletin/page-actions/list.tmpl
@@ -2,28 +2,31 @@
   <h2 class="ons-u-fs-r--b ons-u-mb-s">
     {{- localise "PageActionsTitle" .Language 4 -}}
   </h2>
+  {{ $twitter := index .ShareLinks "twitter" }}
+  {{ $linkedin := index .ShareLinks "linkedin" }}
+  {{ $email := index .ShareLinks "email" }}
   <ul class="ons-list ons-list--bare ons-list--icons">
-    <li class="ons-list__item">
+    <li class="ons-list__item {{ if $twitter.RequiresJavaScript }}nojs--hide{{ end }}">
       <span class="ons-list__prefix">
         {{ template "icons/twitter" }}
       </span>
-      <a href="">
+      <a href="{{ $twitter.Url }}">
         {{- localise "PageActionTweet" .Language 1 -}}
       </a>
     </li>
-    <li class="ons-list__item">
+    <li class="ons-list__item {{ if $linkedin.RequiresJavaScript }}nojs--hide{{ end }}">
       <span class="ons-list__prefix">
         {{ template "icons/linkedin" }}
       </span>
-      <a href="">
+      <a href="{{ $linkedin.Url }}">
         {{- localise "PageActionLinkedIn" .Language 1 -}}
       </a>
     </li>
-    <li class="ons-list__item">
+    <li class="ons-list__item {{ if $email.RequiresJavaScript }}nojs--hide{{ end }}">
       <span class="ons-list__prefix">
         {{ template "icons/email" }}
       </span>
-      <a href="">
+      <a href="{{ $email.Url }}">
         {{- localise "PageActionEmail" .Language 1 -}}
       </a>
     </li>

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.135.0
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-net v1.4.1
-	github.com/ONSdigital/dp-renderer v1.32.1
+	github.com/ONSdigital/dp-renderer v1.38.1
 	github.com/ONSdigital/log.go/v2 v2.2.0
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/ONSdigital/dp-net v1.4.1/go.mod h1:VK8dah+G0TeVO/Os/w17Rk4WM6hIGmdUXr
 github.com/ONSdigital/dp-net/v2 v2.0.0/go.mod h1:Pv/35rM5tCLYdVdIZ5KoGu2EUXv/87fWTptlVTlS5MY=
 github.com/ONSdigital/dp-net/v2 v2.2.0 h1:EHh7n6pdI82F7Ejmbt30d47NC+hzA/RgD9g8i3by4Tk=
 github.com/ONSdigital/dp-net/v2 v2.2.0/go.mod h1:Pv/35rM5tCLYdVdIZ5KoGu2EUXv/87fWTptlVTlS5MY=
-github.com/ONSdigital/dp-renderer v1.32.1 h1:OMtq8006DLiRVV2qHkMU1FOVyEYSdBMyN/po2IjTOgE=
-github.com/ONSdigital/dp-renderer v1.32.1/go.mod h1:odKmVudLXN9WaenfrKgGGrfmZARZFemSNtSy6gxTue8=
+github.com/ONSdigital/dp-renderer v1.38.1 h1:41wDeTRXaaugOU7YraTd43p6fuhskHzVKfNtYy3UihI=
+github.com/ONSdigital/dp-renderer v1.38.1/go.mod h1:odKmVudLXN9WaenfrKgGGrfmZARZFemSNtSy6gxTue8=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -59,7 +59,6 @@ func Bulletin(cfg config.Config, rc RenderClient, zc ZebedeeClient, ac ArticlesA
 
 func bulletin(w http.ResponseWriter, req *http.Request, userAccessToken, collectionID, lang string, rc RenderClient, zc ZebedeeClient, ac ArticlesApiClient, cfg config.Config) {
 	ctx := req.Context()
-
 	bulletin, err := ac.GetLegacyBulletin(ctx, userAccessToken, collectionID, lang, req.URL.EscapedPath())
 
 	if err != nil {
@@ -74,6 +73,10 @@ func bulletin(w http.ResponseWriter, req *http.Request, userAccessToken, collect
 	}
 
 	basePage := rc.NewBasePageModel()
-	model := mapper.CreateBulletinModel(basePage, *bulletin, breadcrumbs, lang)
+	requestProtocol := "http"
+	if req.TLS != nil {
+		requestProtocol = "https"
+	}
+	model := mapper.CreateBulletinModel(basePage, *bulletin, breadcrumbs, lang, requestProtocol)
 	rc.BuildPage(w, model, "bulletin")
 }


### PR DESCRIPTION
### What

Email, Twitter (Tweet), and LinkedIn share links implemented using `ShareLink{}` from dp-renderer v1.38.1

Actions only available on platforms that require JavaScript (Twitter and LinkedIn) are hidden when this is unavailable in the user's browser.

With JavaScript
<img width="346" alt="Screenshot 2022-07-15 at 12 21 16" src="https://user-images.githubusercontent.com/912770/179254063-ee123a29-4232-434b-bc4a-ddb767dff9b4.png">

Without JavaScript
<img width="297" alt="Screenshot 2022-07-15 at 12 21 26" src="https://user-images.githubusercontent.com/912770/179254072-56b5e463-0c38-47c5-8d55-89591edbef2f.png">

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Visit an article e.g. http://localhost:26500/economy/grossdomesticproductgdp/bulletins/gdpmonthlyestimateuk/august2019
- Verify that of the three sharing options, only email is visible when JavaScript is disabled
- Verify that each of the three sharing options take the user to the appropriate application or service

### Who can review

Frontend / design system developers
