### PR TITLE
Feature/print action

### DIFF
--- a/assets/templates/partials/bulletin/contents/body.tmpl
+++ b/assets/templates/partials/bulletin/contents/body.tmpl
@@ -1,5 +1,5 @@
-<div class="ons-pl-grid-col">
-  <div class="ons-u-mb-l">
+<div class="content-body ons-pl-grid-col">
+  <div class="content-length-toggle ons-u-mb-l">
     <a href="">Read long version</a>
   </div>
   {{ range $sectionView := .ContentsView }}

--- a/assets/templates/partials/bulletin/page-actions/list.tmpl
+++ b/assets/templates/partials/bulletin/page-actions/list.tmpl
@@ -6,51 +6,51 @@
   {{ $linkedin := index .ShareLinks "linkedin" }}
   {{ $email := index .ShareLinks "email" }}
   <ul class="ons-list ons-list--bare ons-list--icons">
-    <li class="ons-list__item {{ if $twitter.RequiresJavaScript }}nojs--hide{{ end }}">
+    <li class="page-action--twitter ons-list__item {{ if $twitter.RequiresJavaScript }}nojs--hide{{ end }}">
       <span class="ons-list__prefix">
         {{ template "icons/twitter" }}
       </span>
-      <a href="{{ $twitter.Url }}">
+      <a class="ons-u-us-no" href="{{ $twitter.Url }}">
         {{- localise "PageActionTweet" .Language 1 -}}
       </a>
     </li>
-    <li class="ons-list__item {{ if $linkedin.RequiresJavaScript }}nojs--hide{{ end }}">
+    <li class="page-action--linkedin ons-list__item {{ if $linkedin.RequiresJavaScript }}nojs--hide{{ end }}">
       <span class="ons-list__prefix">
         {{ template "icons/linkedin" }}
       </span>
-      <a href="{{ $linkedin.Url }}">
+      <a class="ons-u-us-no" href="{{ $linkedin.Url }}">
         {{- localise "PageActionLinkedIn" .Language 1 -}}
       </a>
     </li>
-    <li class="ons-list__item {{ if $email.RequiresJavaScript }}nojs--hide{{ end }}">
+    <li class="page-action--email ons-list__item {{ if $email.RequiresJavaScript }}nojs--hide{{ end }}">
       <span class="ons-list__prefix">
         {{ template "icons/email" }}
       </span>
-      <a href="{{ $email.Url }}">
+      <a class="ons-u-us-no" href="{{ $email.Url }}">
         {{- localise "PageActionEmail" .Language 1 -}}
       </a>
     </li>
-    <li class="ons-list__item">
+    <li class="page-action--copy-link ons-list__item">
       <span class="ons-list__prefix">
         {{ template "icons/copy-link" }}
       </span>
-      <a href="">
+      <a class="ons-u-us-no" href="">
         {{- localise "PageActionCopyLink" .Language 1 -}}
       </a>
     </li>
-    <li class="ons-list__item">
+    <li class="page-action--download ons-list__item">
       <span class="ons-list__prefix page-action__icon--no-roundel">
         {{ template "icons/download" }}
       </span>
-      <a href="{{ .URI }}/pdf">
+      <a class="ons-u-us-no" href="{{ .URI }}/pdf">
         {{- localise "PageActionDownloadPDF" .Language 1 -}}
       </a>
     </li>
-    <li class="ons-list__item">
+    <li class="page-action--print ons-list__item nojs--hide">
       <span class="ons-list__prefix page-action__icon--no-roundel">
         {{ template "icons/print" }}
       </span>
-      <a href="">
+      <a class="ons-u-us-no" href="">
         {{- localise "PageActionPrint" .Language 1 -}}
       </a>
     </li>

--- a/assets/templates/partials/bulletin/status-header.tmpl
+++ b/assets/templates/partials/bulletin/status-header.tmpl
@@ -1,4 +1,4 @@
-<ul class="ons-list ons-list--bare ons-list--inline ons-u-mb-xl">
+<ul class="status-header ons-list ons-list--bare ons-list--inline ons-u-mb-xl">
   <li class="ons-list__item ons-u-mr-xs@xs">
     <span class="ons-u-fs-r--b">{{ localise "StatusLineReleased" .Language 1 }}:</span>
     <span class="ons-u-nowrap">{{ dateTimeOnsDatePatternFormat .ReleaseDate .Language }}</span>
@@ -6,7 +6,7 @@
   <li class="ons-list__item ons-u-mt-xs@xxs@m ons-u-mr-s@xxs@m ons-u-mr-l@m">
     {{ template "partials/bulletin/status-header/edition-version-sticker" . }}
   </li>
-  <li class="ons-list__item ons-u-mt-xs@xxs@m">
+  <li class="version-link ons-list__item ons-u-mt-xs@xxs@m">
     {{ template "partials/bulletin/status-header/edition-version-link" . }}
   </li>
 </ul>

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/b6824ed"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/80d766d"
 	}
 	return cfg, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.BindAddr, ShouldEqual, ":26500")
 				So(cfg.Debug, ShouldBeFalse)
 				So(cfg.SiteDomain, ShouldEqual, "localhost")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/b6824ed")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/80d766d")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)


### PR DESCRIPTION
### What

Page action "Print" is enabled

![Screenshot 2022-07-21 at 12 47 05](https://user-images.githubusercontent.com/912770/180206513-269125c7-cb22-410a-87df-34cade755cb3.png)

The browser's print preview shows a simplified version of the article/bulletin, tailored for printing.
<img width="1001" alt="Screenshot 2022-07-21 at 12 48 20" src="https://user-images.githubusercontent.com/912770/180207018-6fa25ee5-2d17-428f-815a-274e0fca2dd5.png">

### How to review

- In a separate shell, run the dp-design-system with `make debug`
- Run this frontend with `make debug`
- View an article or bulletin, for example http://localhost:26500/economy/grossdomesticproductgdp/bulletins/gdpmonthlyestimateuk/august2019
- Click on the Print page action to display the browser's print preview dialog
- Verify that accessing the print preview dialog through the browser's menu e.g. File -> Print... shows the same preview of the article/bulletin 

### Who can review

Frontend / design system developers
