### PR TITLE
Task/page action aria labels

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -157,25 +157,49 @@ other = "Gweithredoedd y dudalen"
 description = "Tweet"
 one = "Trydariad"
 
+[PageActionTweetArialLabel]
+description = "Tweet"
+one = "Share this page on Twitter (cy)"
+
 [PageActionLinkedIn]
 description = "LinkedIn"
 one = "LinkedIn"
+
+[PageActionLinkedInAriaLabel]
+description = "LinkedIn"
+one = "Share this page on LinkedIn (cy)"
 
 [PageActionEmail]
 description = "Email"
 one = "E-bost"
 
+[PageActionEmailAriaLabel]
+description = "Email"
+one = "Share this page via Email (cy)"
+
 [PageActionCopyLink]
 description = "Copy link"
 one = "Copïo'r ddolen"
+
+[PageActionCopyLinkAriaLabel]
+description = "Copy link"
+one = "Copy the link to this page to the clipboard (cy)"
 
 [PageActionDownloadPDF]
 description = "Download PDF"
 one = "Lawrlwytho fel PDF"
 
+[PageActionDownloadPDFAriaLabel]
+description = "Download PDF"
+one = "Download this page as a PDF (cy)"
+
 [PageActionPrint]
 description = "Print"
 one = "Argraffu"
+
+[PageActionPrintAriaLabel]
+description = "Print"
+one = "Print this page (cy)"
 
 [PageContentsTitle]
 description = "Page contents"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -157,25 +157,49 @@ other = "Page actions"
 description = "Tweet"
 one = "Tweet"
 
+[PageActionTweetArialLabel]
+description = "Tweet"
+one = "Share this page on Twitter"
+
 [PageActionLinkedIn]
 description = "LinkedIn"
 one = "LinkedIn"
+
+[PageActionLinkedInAriaLabel]
+description = "LinkedIn"
+one = "Share this page on LinkedIn"
 
 [PageActionEmail]
 description = "Email"
 one = "Email"
 
+[PageActionEmailAriaLabel]
+description = "Email"
+one = "Share this page via Email"
+
 [PageActionCopyLink]
 description = "Copy link"
 one = "Copy link"
+
+[PageActionCopyLinkAriaLabel]
+description = "Copy link"
+one = "Copy the link to this page to the clipboard"
 
 [PageActionDownloadPDF]
 description = "Download PDF"
 one = "Download PDF"
 
+[PageActionDownloadPDFAriaLabel]
+description = "Download PDF"
+one = "Download this page as a PDF"
+
 [PageActionPrint]
 description = "Print"
 one = "Print"
+
+[PageActionPrintAriaLabel]
+description = "Print"
+one = "Print this page"
 
 [PageContentsTitle]
 description = "Page contents"

--- a/assets/templates/partials/bulletin/page-actions/list.tmpl
+++ b/assets/templates/partials/bulletin/page-actions/list.tmpl
@@ -10,7 +10,11 @@
       <span class="ons-list__prefix">
         {{ template "icons/twitter" }}
       </span>
-      <a class="ons-u-us-no" href="{{ $twitter.Url }}">
+      <a
+        class="ons-u-us-no"
+        href="{{ $twitter.Url }}"
+        aria-label="{{ localise "PageActionTweetArialLabel" .Language 1 }}"
+      >
         {{- localise "PageActionTweet" .Language 1 -}}
       </a>
     </li>
@@ -18,7 +22,11 @@
       <span class="ons-list__prefix">
         {{ template "icons/linkedin" }}
       </span>
-      <a class="ons-u-us-no" href="{{ $linkedin.Url }}">
+      <a
+        class="ons-u-us-no"
+        href="{{ $linkedin.Url }}"
+        aria-label="{{ localise "PageActionLinkedInAriaLabel" .Language 1 }}"
+      >
         {{- localise "PageActionLinkedIn" .Language 1 -}}
       </a>
     </li>
@@ -26,7 +34,11 @@
       <span class="ons-list__prefix">
         {{ template "icons/email" }}
       </span>
-      <a class="ons-u-us-no" href="{{ $email.Url }}">
+      <a
+        class="ons-u-us-no"
+        href="{{ $email.Url }}"
+        aria-label="{{ localise "PageActionEmailAriaLabel" .Language 1 }}"
+      >
         {{- localise "PageActionEmail" .Language 1 -}}
       </a>
     </li>
@@ -34,7 +46,11 @@
       <span class="ons-list__prefix">
         {{ template "icons/copy-link" }}
       </span>
-      <a class="ons-u-us-no" href="">
+      <a
+        class="ons-u-us-no"
+        href=""
+        aria-label="{{ localise "PageActionCopyLinkAriaLabel" .Language 1 }}"
+      >
         {{- localise "PageActionCopyLink" .Language 1 -}}
       </a>
     </li>
@@ -42,7 +58,11 @@
       <span class="ons-list__prefix page-action__icon--no-roundel">
         {{ template "icons/download" }}
       </span>
-      <a class="ons-u-us-no" href="{{ .URI }}/pdf">
+      <a
+        class="ons-u-us-no"
+        href="{{ .URI }}/pdf"
+        aria-label="{{ localise "PageActionDownloadPDFAriaLabel" .Language 1 }}"
+      >
         {{- localise "PageActionDownloadPDF" .Language 1 -}}
       </a>
     </li>
@@ -50,7 +70,11 @@
       <span class="ons-list__prefix page-action__icon--no-roundel">
         {{ template "icons/print" }}
       </span>
-      <a class="ons-u-us-no" href="">
+      <a
+        class="ons-u-us-no"
+        href=""
+        aria-label="{{ localise "PageActionPrintAriaLabel" .Language 1 }}"
+      >
         {{- localise "PageActionPrint" .Language 1 -}}
       </a>
     </li>


### PR DESCRIPTION
### What

Page actions have an ARIA label to distinguish them from other, similarly named links on the page e.g. the page action "LinkedIn" (as in, share on LinkedIn), and the footer link "LinkedIn" (as in, follow ONS on LinkedIn).

This fixes a warning from axe DevTools about similarly named links.

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- View an article e.g. http://localhost:26500/economy/grossdomesticproductgdp/bulletins/gdpmonthlyestimateuk/august2019
- Run the axe DevTools and verify that no warnings are raised against the page actions for similarly named links.

Note that the content of the article itself is beyond our control, so axe DevTools may issue warnings about links within the article being named similarly to each other. These warnings can be safely ignored.

### Who can review

Front end / design system developers.
