### PR TITLE
Back to contents link shown on mobile

### DIFF
--- a/assets/templates/partials/bulletin/contents/body.tmpl
+++ b/assets/templates/partials/bulletin/contents/body.tmpl
@@ -4,7 +4,7 @@
       {{ $content := index $sectionView.Source $sectionView.Index }}
       <h2>{{ $content.Title }}</h2>
       {{ markdown $content.Markdown }}
-      <div class="ons-u-mb-l ons-u-mt-l ons-u-vh@m@xxl">
+      <div class="ons-u-mb-l ons-u-mt-l ons-u-vh@m">
         {{ template "partials/back-to" $sectionView }}
       </div>
     </section>

--- a/assets/templates/partials/bulletin/contents/body.tmpl
+++ b/assets/templates/partials/bulletin/contents/body.tmpl
@@ -4,6 +4,9 @@
       {{ $content := index $sectionView.Source $sectionView.Index }}
       <h2>{{ $content.Title }}</h2>
       {{ markdown $content.Markdown }}
+      <div class="ons-u-mb-l ons-u-mt-l ons-u-vh@m@xxl">
+        {{ template "partials/back-to" $sectionView }}
+      </div>
     </section>
   {{ end }}
 </div>

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.135.0
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-net v1.4.1
-	github.com/ONSdigital/dp-renderer v1.38.1
+	github.com/ONSdigital/dp-renderer v1.40.0
 	github.com/ONSdigital/log.go/v2 v2.2.0
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/ONSdigital/dp-net v1.4.1/go.mod h1:VK8dah+G0TeVO/Os/w17Rk4WM6hIGmdUXr
 github.com/ONSdigital/dp-net/v2 v2.0.0/go.mod h1:Pv/35rM5tCLYdVdIZ5KoGu2EUXv/87fWTptlVTlS5MY=
 github.com/ONSdigital/dp-net/v2 v2.2.0 h1:EHh7n6pdI82F7Ejmbt30d47NC+hzA/RgD9g8i3by4Tk=
 github.com/ONSdigital/dp-net/v2 v2.2.0/go.mod h1:Pv/35rM5tCLYdVdIZ5KoGu2EUXv/87fWTptlVTlS5MY=
-github.com/ONSdigital/dp-renderer v1.38.1 h1:41wDeTRXaaugOU7YraTd43p6fuhskHzVKfNtYy3UihI=
-github.com/ONSdigital/dp-renderer v1.38.1/go.mod h1:odKmVudLXN9WaenfrKgGGrfmZARZFemSNtSy6gxTue8=
+github.com/ONSdigital/dp-renderer v1.40.0 h1:q6Es+y7nYtGJoyz1jyDUfwsBazaB+TuhZfLV0phYDdY=
+github.com/ONSdigital/dp-renderer v1.40.0/go.mod h1:q/zlK9Qc7b95w7XPfgS7RPLID++CZgaAn0q51QCqZew=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -44,10 +44,12 @@ type BulletinModel struct {
 
 // Intermediate view to aid template rendering of Sections and Accordion
 type ViewSection struct {
-	Id     string
-	Type   string
-	Source *[]Section
-	Index  int
+	Id       string
+	Type     string
+	Source   *[]Section
+	Index    int
+	BackTo   coreModel.BackTo
+	Language string
 }
 
 type Contact struct {
@@ -361,6 +363,17 @@ func populateContents(model *BulletinModel) {
 	appendSections(&model.Sections, "section", &views)
 	appendSections(&model.Accordion, "accordion", &views)
 
+	for index := range views {
+		views[index].BackTo = coreModel.BackTo{
+			Text: coreModel.Localisation{
+				LocaleKey: "BackToContents",
+				Plural:    4,
+			},
+			AnchorFragment: "toc",
+		}
+		views[index].Language = model.Language
+	}
+
 	model.TableOfContents = createTableOfContents(views)
 	model.ContentsView = views
 }
@@ -394,6 +407,7 @@ func getCurrentUrl(requestProtocol, siteDomain, path, lang string) string {
 
 func createTableOfContents(views []ViewSection) coreModel.TableOfContents {
 	toc := coreModel.TableOfContents{
+		Id: "toc",
 		AriaLabel: coreModel.Localisation{
 			LocaleKey: "TableOfContents",
 			Plural:    1,


### PR DESCRIPTION
### What

After every section within the body of an article, a "Back to contents" link is shown on mobile that takes the user back to the table of contents at the top of the page.

"Back to contents" link:
<img width="375" alt="Screenshot 2022-07-28 at 18 10 04" src="https://user-images.githubusercontent.com/912770/181597566-da420c83-d34e-4bc6-a68a-c2026d6ca342.png">

Clicking it takes the user back to the table of contents:
<img width="378" alt="Screenshot 2022-07-28 at 18 10 15" src="https://user-images.githubusercontent.com/912770/181597577-af082013-a67c-41a6-abb0-8e623348d167.png">

### How to review

- In a separate shell, run the dp-design-system with `make debug`
- Run this frontend with `make debug`
- View a suitably long article e.g. http://localhost:26500/economy/grossdomesticproductgdp/bulletins/gdpmonthlyestimateuk/august2019
- Verify that these "Back to contents" links are not visible on tablet or desktop views
- Verify that these "Back to contents" links are visible on the mobile view
- Verify that the links take you back to the table of contents at the top of the page when clicked

NB: Currently there is no Welsh translation available for "Back to contents"

### Who can review

Frontend / design system developers
