### PR TITLE
Import dp-design-system v1.25.0 for copy-link support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/80d766d"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/dd99d1e"
 	}
 	return cfg, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.BindAddr, ShouldEqual, ":26500")
 				So(cfg.Debug, ShouldBeFalse)
 				So(cfg.SiteDomain, ShouldEqual, "localhost")
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/80d766d")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/dd99d1e")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)


### PR DESCRIPTION
### What

Page action "Copy link" copies the URL of the current document to the clipboard.

<img width="334" alt="Screenshot 2022-07-29 at 10 47 04" src="https://user-images.githubusercontent.com/912770/181733099-02e88c16-bcac-49d3-aa9e-88ed636eccac.png">

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Visit an article e.g. http://localhost:26500/economy/grossdomesticproductgdp/bulletins/gdpmonthlyestimateuk/august2019
- Verify that the "Copy link" action works by clicking on it and pasting the contents of the clipboard into a text editor or browser and comparing it to the URL of the original article

### Who can review

Anyone
