### PR TITLE
Display service message and emergency banner from homepage

### DIFF
--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -27,6 +27,7 @@ type RenderClient interface {
 // ZebedeeClient is an interface for zebedee client
 type ZebedeeClient interface {
 	GetBreadcrumb(ctx context.Context, userAccessToken, collectionID, lang, uri string) ([]zebedee.Breadcrumb, error)
+	GetHomepageContent(ctx context.Context, userAccessToken, collectionID, lang, path string) (m zebedee.HomepageContent, err error)
 }
 
 // ArticlesApiClient is an interface for the Articles API client

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -142,6 +142,7 @@ func TestUnitHandlers(t *testing.T) {
 		Convey("it returns 200 when rendered succesfully", func() {
 			mockArticlesApiClient.EXPECT().GetLegacyBulletin(ctx, accessToken, collectionID, lang, url).Return(&b, nil)
 			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, accessToken, collectionID, lang, b.URI)
+			mockZebedeeClient.EXPECT().GetHomepageContent(ctx, accessToken, collectionID, lang, "/")
 			mockRenderClient.EXPECT().NewBasePageModel()
 			mockRenderClient.EXPECT().BuildPage(w, gomock.Any(), "bulletin")
 
@@ -156,6 +157,7 @@ func TestUnitHandlers(t *testing.T) {
 		Convey("it returns 200 when rendered succesfully without headers or cookies", func() {
 			mockArticlesApiClient.EXPECT().GetLegacyBulletin(ctx, "", "", lang, url).Return(&b, nil)
 			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, "", "", lang, b.URI)
+			mockZebedeeClient.EXPECT().GetHomepageContent(ctx, "", "", lang, "/")
 			mockRenderClient.EXPECT().NewBasePageModel()
 			mockRenderClient.EXPECT().BuildPage(w, gomock.Any(), "bulletin")
 
@@ -167,6 +169,7 @@ func TestUnitHandlers(t *testing.T) {
 		})
 
 		Convey("it returns 500 when there is an error getting the bulletin from Zebedee", func() {
+			mockZebedeeClient.EXPECT().GetHomepageContent(ctx, accessToken, collectionID, lang, "/")
 			mockArticlesApiClient.EXPECT().GetLegacyBulletin(ctx, accessToken, collectionID, lang, url).Return(nil, errors.New(("error reading data")))
 
 			req := httptest.NewRequest("GET", fmt.Sprintf(requestUrlFormat, url), nil)
@@ -178,6 +181,7 @@ func TestUnitHandlers(t *testing.T) {
 		})
 
 		Convey("it returns 500 when there is an error getting the breadcrumbs from Zebedee", func() {
+			mockZebedeeClient.EXPECT().GetHomepageContent(ctx, accessToken, collectionID, lang, "/")
 			mockArticlesApiClient.EXPECT().GetLegacyBulletin(ctx, accessToken, collectionID, lang, url).Return(&b, nil)
 			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, accessToken, collectionID, lang, b.URI).Return([]zebedee.Breadcrumb{}, errors.New(("error reading breadcrumbs")))
 			req := httptest.NewRequest("GET", fmt.Sprintf(requestUrlFormat, url), nil)

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -153,6 +153,21 @@ func (mr *MockZebedeeClientMockRecorder) GetBreadcrumb(ctx, userAccessToken, col
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBreadcrumb", reflect.TypeOf((*MockZebedeeClient)(nil).GetBreadcrumb), ctx, userAccessToken, collectionID, lang, uri)
 }
 
+// GetHomepageContent mocks base method.
+func (m *MockZebedeeClient) GetHomepageContent(ctx context.Context, userAccessToken, collectionID, lang, path string) (zebedee.HomepageContent, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHomepageContent", ctx, userAccessToken, collectionID, lang, path)
+	ret0, _ := ret[0].(zebedee.HomepageContent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHomepageContent indicates an expected call of GetHomepageContent.
+func (mr *MockZebedeeClientMockRecorder) GetHomepageContent(ctx, userAccessToken, collectionID, lang, path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHomepageContent", reflect.TypeOf((*MockZebedeeClient)(nil).GetHomepageContent), ctx, userAccessToken, collectionID, lang, path)
+}
+
 // MockArticlesApiClient is a mock of ArticlesApiClient interface.
 type MockArticlesApiClient struct {
 	ctrl     *gomock.Controller

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -214,11 +214,26 @@ func CreateSixteensBulletinModel(basePage coreModel.Page, bulletin articles.Bull
 	return model
 }
 
-func CreateBulletinModel(basePage coreModel.Page, bulletin articles.Bulletin, bcs []zebedee.Breadcrumb, lang, requestProtocol string) BulletinModel {
+func mapEmergencyBanner(bannerData zebedee.EmergencyBanner) coreModel.EmergencyBanner {
+	var mappedEmergencyBanner coreModel.EmergencyBanner
+	emptyBannerObj := zebedee.EmergencyBanner{}
+	if bannerData != emptyBannerObj {
+		mappedEmergencyBanner.Title = bannerData.Title
+		mappedEmergencyBanner.Type = strings.Replace(bannerData.Type, "_", "-", -1)
+		mappedEmergencyBanner.Description = bannerData.Description
+		mappedEmergencyBanner.URI = bannerData.URI
+		mappedEmergencyBanner.LinkText = bannerData.LinkText
+	}
+	return mappedEmergencyBanner
+}
+
+func CreateBulletinModel(basePage coreModel.Page, bulletin articles.Bulletin, bcs []zebedee.Breadcrumb, lang, requestProtocol, serviceMessage string, emergencyBannerContent zebedee.EmergencyBanner) BulletinModel {
 	model := BulletinModel{
 		Page: basePage,
 	}
 	model.Language = lang
+	model.ServiceMessage = serviceMessage
+	model.EmergencyBanner = mapEmergencyBanner(emergencyBannerContent)
 	model.BetaBannerEnabled = true
 	model.Type = bulletin.Type
 	model.Metadata = coreModel.Metadata{

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -459,15 +459,38 @@ func TestUnitMapper(t *testing.T) {
 				URI: "/economy/product",
 			},
 		}
+
+		serviceMessage := "Service Message"
+		emergencyBannerTitle := "Emergency Title"
+		emergencyBannerType := "notable-death"
+		emergencyBannerDescription := "Emergency Description"
+		emergencyBannerUri := "https://example.com/emergency"
+		emergencyBannerLinkText := "Attention, this is an emergency. There's an emergency going on."
+		bannerData := zebedee.EmergencyBanner{
+			Title:       emergencyBannerTitle,
+			Type:        emergencyBannerType,
+			Description: emergencyBannerDescription,
+			URI:         emergencyBannerUri,
+			LinkText:    emergencyBannerLinkText,
+		}
+
 		Convey("When the bulletin URI is not a previous version", func() {
 			bulletin.URI = "the/bulletin/uri/path/version"
+
 			Convey("CreateBulletinModel maps correctly", func() {
 				requestProtocol := "https"
-				model := CreateBulletinModel(basePage, bulletin, breadcrumbs, "cy", requestProtocol)
+				model := CreateBulletinModel(basePage, bulletin, breadcrumbs, "cy", requestProtocol, serviceMessage, bannerData)
 
 				So(model.Page.PatternLibraryAssetsPath, ShouldEqual, basePage.PatternLibraryAssetsPath)
 				So(model.Page.SiteDomain, ShouldEqual, basePage.SiteDomain)
 				So(model.BetaBannerEnabled, ShouldBeTrue)
+				So(model.BetaBannerEnabled, ShouldBeTrue)
+				So(model.ServiceMessage, ShouldEqual, serviceMessage)
+				So(model.EmergencyBanner.Title, ShouldEqual, emergencyBannerTitle)
+				So(model.EmergencyBanner.Type, ShouldEqual, emergencyBannerType)
+				So(model.EmergencyBanner.Description, ShouldEqual, emergencyBannerDescription)
+				So(model.EmergencyBanner.URI, ShouldEqual, emergencyBannerUri)
+				So(model.EmergencyBanner.LinkText, ShouldEqual, emergencyBannerLinkText)
 				So(model.Metadata.Title, ShouldEqual, bulletin.Description.Title)
 				So(model.Metadata.Description, ShouldEqual, bulletin.Description.MetaDescription)
 				So(model.Metadata.Keywords, ShouldResemble, bulletin.Description.Keywords)
@@ -528,10 +551,17 @@ func TestUnitMapper(t *testing.T) {
 			bulletin.URI = "the/bulletin/uri/path/previous/version"
 			Convey("CreateBulletinModel maps correctly", func() {
 				requestProtocol := "https"
-				model := CreateBulletinModel(basePage, bulletin, breadcrumbs, "cy", requestProtocol)
+				model := CreateBulletinModel(basePage, bulletin, breadcrumbs, "cy", requestProtocol, serviceMessage, bannerData)
 
 				So(model.Page.PatternLibraryAssetsPath, ShouldEqual, basePage.PatternLibraryAssetsPath)
 				So(model.Page.SiteDomain, ShouldEqual, basePage.SiteDomain)
+				So(model.BetaBannerEnabled, ShouldBeTrue)
+				So(model.ServiceMessage, ShouldEqual, serviceMessage)
+				So(model.EmergencyBanner.Title, ShouldEqual, emergencyBannerTitle)
+				So(model.EmergencyBanner.Type, ShouldEqual, emergencyBannerType)
+				So(model.EmergencyBanner.Description, ShouldEqual, emergencyBannerDescription)
+				So(model.EmergencyBanner.URI, ShouldEqual, emergencyBannerUri)
+				So(model.EmergencyBanner.LinkText, ShouldEqual, emergencyBannerLinkText)
 				So(model.Metadata.Title, ShouldEqual, bulletin.Description.Title)
 				So(model.Metadata.Description, ShouldEqual, bulletin.Description.MetaDescription)
 				So(model.Metadata.Keywords, ShouldResemble, bulletin.Description.Keywords)


### PR DESCRIPTION
### What

Echoes the service message and emergency banner on the homepage, when present.

<img width="1145" alt="Screenshot 2022-09-13 at 16 01 54" src="https://user-images.githubusercontent.com/912770/189939365-864886a0-f4a5-4e19-8253-66021766cbf8.png">

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Visit any article or bulletin and verify that the service message and emergency banner set in your environment via Florence is displayed

### Who can review

Go / frontend developers
