### PR TITLE
Add route to get underlying bulletin data

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -95,7 +95,6 @@ func BulletinData(cfg config.Config, ac ArticlesApiClient) http.HandlerFunc {
 	return dphandlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, accessToken string) {
 		bulletinUrl := strings.TrimSuffix(req.URL.EscapedPath(), "/data")
 		bulletin, err := ac.GetLegacyBulletin(req.Context(), accessToken, collectionID, lang, bulletinUrl)
-
 		if err != nil {
 			setStatusCode(req, w, err)
 			return

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -26,5 +26,6 @@ func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients) {
 	log.Info(ctx, "adding routes")
 	r.StrictSlash(true).Path("/health").HandlerFunc(c.HealthCheckHandler)
 	r.StrictSlash(true).Path("/sixteens{uri:/.*}").Methods("GET").HandlerFunc(handlers.SixteensBulletin(*cfg, c.Render, c.Zebedee, c.ArticlesAPI))
+	r.StrictSlash(true).Path("/{uri:.*}/data").Methods("GET").HandlerFunc(handlers.BulletinData(*cfg, c.ArticlesAPI))
 	r.StrictSlash(true).Path("/{uri:.*}").Methods("GET").HandlerFunc(handlers.Bulletin(*cfg, c.Render, c.Zebedee, c.ArticlesAPI))
 }


### PR DESCRIPTION
### What

The JSON used to render an article or bulletin is available with a `/data` suffix on `/path/to/the/article/data`.

### How to review

- In a separate shell, run dp-design-system with `make debug`
- Run this frontend with `make debug`
- Visit an article e.g. http://localhost:26500/economy/economicoutputandproductivity/output/articles/foo1119/othercontent
- Verify that the article is rendered as usual
- Append `/data` to the URL e.g. http://localhost:26500/economy/economicoutputandproductivity/output/articles/foo1119/othercontent/data
- Verify that the article data is displayed as JSON

### Who can review

Go developers
